### PR TITLE
add support for redpallas

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,14 @@ jobs:
           # GitHub displays the clippy job and its results as separate entries
           name: Clippy (stable) Results
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -D warnings
+          # Notet that we don't use --all-features because we go against Rust
+          # convention and have a non-additive "redpallas" feature, and the
+          # tests only work without it currently.
+          args: --all-targets -- -D warnings
 
       - name: Run clippy manually without annotations
         if: ${{ !steps.check_permissions.outputs.has-permission }}
-        run: cargo clippy --all-features --all-targets -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
   fmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,12 +75,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -154,6 +200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
+
+[[package]]
 name = "coordinator"
 version = "0.1.0"
 dependencies = [
@@ -163,6 +215,7 @@ dependencies = [
  "hex",
  "itertools 0.11.0",
  "rand",
+ "reddsa",
  "serde_json",
  "thiserror",
 ]
@@ -332,6 +385,7 @@ dependencies = [
  "itertools 0.11.0",
  "pipe",
  "rand",
+ "reddsa",
  "serde_json",
  "thiserror",
 ]
@@ -389,6 +443,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,16 +487,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "frost-core"
+version = "0.6.0"
+source = "git+https://github.com/ZcashFoundation/frost.git?rev=08cbe8f591d178879c26de3672bf11f239a361fe#08cbe8f591d178879c26de3672bf11f239a361fe"
+dependencies = [
+ "byteorder",
+ "criterion",
+ "debugless-unwrap",
+ "derive-getters",
+ "hex",
+ "itertools 0.11.0",
+ "proptest",
+ "rand_core",
+ "serde",
+ "serde_json",
+ "serdect",
+ "thiserror",
+ "visibility",
+ "zeroize",
+]
+
+[[package]]
 name = "frost-ed25519"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c69d652160d8031e2cf2b57d9e9320cf5b5ba2be18081511411d6355df87f3d1"
 dependencies = [
  "curve25519-dalek",
- "frost-core",
+ "frost-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core",
  "sha2",
 ]
+
+[[package]]
+name = "frost-rerandomized"
+version = "0.6.0"
+source = "git+https://github.com/ZcashFoundation/frost.git?rev=08cbe8f591d178879c26de3672bf11f239a361fe#08cbe8f591d178879c26de3672bf11f239a361fe"
+dependencies = [
+ "derive-getters",
+ "frost-core 0.6.0 (git+https://github.com/ZcashFoundation/frost.git?rev=08cbe8f591d178879c26de3672bf11f239a361fe)",
+ "rand_core",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -453,6 +554,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -547,6 +659,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jubjub"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
+dependencies = [
+ "bitvec",
+ "bls12_381",
+ "ff",
+ "group",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,7 +763,21 @@ dependencies = [
  "frost-ed25519",
  "hex",
  "rand",
+ "reddsa",
  "serde_json",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "ff",
+ "group",
+ "rand",
+ "static_assertions",
+ "subtle",
 ]
 
 [[package]]
@@ -734,6 +874,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +938,24 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "reddsa"
+version = "0.5.1"
+source = "git+https://github.com/ZcashFoundation/reddsa.git?rev=8534e283acf0015cc2450e2a6b49685a3bb3145d#8534e283acf0015cc2450e2a6b49685a3bb3145d"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "frost-rerandomized",
+ "group",
+ "hex",
+ "jubjub",
+ "pasta_curves",
+ "rand_core",
+ "serde",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]
@@ -966,6 +1130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1162,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1046,6 +1222,7 @@ dependencies = [
  "hex",
  "itertools 0.11.0",
  "rand",
+ "reddsa",
  "serde_json",
  "thiserror",
 ]
@@ -1270,6 +1447,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zeroize"

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -8,9 +8,14 @@ edition = "2021"
 [dependencies]
 eyre = "0.6.8"
 frost-ed25519 = { version = "0.6.0", features = ["serde"] }
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "8534e283acf0015cc2450e2a6b49685a3bb3145d", features = ["frost"] }
 hex = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
 rand = "0.8"
 serde_json = "1.0"
 itertools = "0.11.0"
 exitcode = "1.1.2"
+
+[features]
+redpallas = []
+default = []

--- a/coordinator/src/cli.rs
+++ b/coordinator/src/cli.rs
@@ -4,6 +4,9 @@ use crate::step_1::step_1;
 use crate::step_2::step_2;
 use crate::step_3::step_3;
 
+#[cfg(feature = "redpallas")]
+use crate::step_3::request_randomizer;
+
 pub fn cli(
     reader: &mut impl BufRead,
     logger: &mut impl Write,
@@ -19,9 +22,19 @@ pub fn cli(
 
     let signing_package = step_2(reader, logger, participants_config.participants.clone())?;
 
+    #[cfg(feature = "redpallas")]
+    let randomizer = request_randomizer(reader, logger)?;
+
     writeln!(logger, "=== STEP 3: BUILD GROUP SIGNATURE ===\n")?;
 
-    step_3(reader, logger, participants_config, signing_package);
+    step_3(
+        reader,
+        logger,
+        participants_config,
+        signing_package,
+        #[cfg(feature = "redpallas")]
+        randomizer,
+    );
 
     writeln!(logger, "=== END ===")?;
 

--- a/coordinator/src/step_1.rs
+++ b/coordinator/src/step_1.rs
@@ -1,4 +1,7 @@
+#[cfg(not(feature = "redpallas"))]
 use frost_ed25519 as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas as frost;
 
 use frost::{keys::PublicKeyPackage, Error, Identifier};
 

--- a/coordinator/src/step_2.rs
+++ b/coordinator/src/step_2.rs
@@ -1,6 +1,9 @@
-use frost::{round1::SigningCommitments, Identifier, SigningPackage};
-
+#[cfg(not(feature = "redpallas"))]
 use frost_ed25519 as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas as frost;
+
+use frost::{round1::SigningCommitments, Identifier, SigningPackage};
 
 use std::{
     collections::BTreeMap,

--- a/dkg/Cargo.toml
+++ b/dkg/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 eyre = "0.6.8"
 frost-ed25519 = { version = "0.6.0", features = ["serde"] }
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "8534e283acf0015cc2450e2a6b49685a3bb3145d", features = ["frost"] }
 hex = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
 rand = "0.8"
@@ -15,3 +16,7 @@ serde_json = "1.0"
 itertools = "0.11.0"
 exitcode = "1.1.2"
 pipe = "0.4.0"
+
+[features]
+redpallas = []
+default = []

--- a/dkg/src/cli.rs
+++ b/dkg/src/cli.rs
@@ -1,6 +1,12 @@
+#[cfg(not(feature = "redpallas"))]
+use frost_ed25519 as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas::keys::PositiveY;
+
 use frost::keys::dkg::{round1, round2};
 use frost::Identifier;
-use frost_ed25519 as frost;
 use rand::thread_rng;
 use std::collections::HashMap;
 use std::io::{BufRead, Write};
@@ -81,6 +87,10 @@ pub fn cli(
         &received_round1_packages,
         &received_round2_packages,
     )?;
+    #[cfg(feature = "redpallas")]
+    let public_key_package = public_key_package.into_positive_y();
+    #[cfg(feature = "redpallas")]
+    let key_package = key_package.into_positive_y();
 
     writeln!(
         logger,

--- a/dkg/src/inputs.rs
+++ b/dkg/src/inputs.rs
@@ -1,9 +1,12 @@
+#[cfg(not(feature = "redpallas"))]
+use frost_ed25519 as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas as frost;
+
 use frost::{
     keys::dkg::{round1, round2},
     Error, Identifier,
 };
-
-use frost_ed25519 as frost;
 
 use eyre::eyre;
 

--- a/participant/Cargo.toml
+++ b/participant/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2021"
 
 [dependencies]
 frost-ed25519 = { version = "0.6.0", features = ["serde"] }
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "8534e283acf0015cc2450e2a6b49685a3bb3145d", features = ["frost"] }
 hex = "0.4"
 rand = "0.8"
 exitcode = "1.1.2"
 serde_json = "1.0"
+
+[features]
+redpallas = []
+default = []

--- a/participant/src/cli.rs
+++ b/participant/src/cli.rs
@@ -1,5 +1,9 @@
-use frost::{round1, Error};
+#[cfg(not(feature = "redpallas"))]
 use frost_ed25519 as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas as frost;
+
+use frost::{round1, Error};
 use participant::round1::{print_values, request_inputs};
 use participant::round2::{generate_signature, print_values_round_2, round_2_request_inputs};
 use participant::Logger;

--- a/participant/src/round1.rs
+++ b/participant/src/round1.rs
@@ -1,10 +1,16 @@
+#[cfg(not(feature = "redpallas"))]
+use frost_ed25519 as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas::keys::PositiveY;
+
 use crate::Logger;
 use frost::{
     keys::{KeyPackage, SecretShare},
     round1::SigningCommitments,
     Error,
 };
-use frost_ed25519 as frost;
 use std::io::BufRead;
 
 // TODO: Rethink the types here. They're inconsistent with each other
@@ -34,6 +40,9 @@ pub fn request_inputs(
         // TODO: Improve error
         serde_json::from_str::<KeyPackage>(&json).map_err(|_| Error::InvalidSecretShare)?
     };
+
+    #[cfg(feature = "redpallas")]
+    let key_package = key_package.into_positive_y();
 
     Ok(Round1Config { key_package })
 }

--- a/participant/src/round2.rs
+++ b/participant/src/round2.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "redpallas")]
+use frost::FieldError;
 #[cfg(not(feature = "redpallas"))]
 use frost_ed25519 as frost;
 #[cfg(feature = "redpallas")]
@@ -45,12 +47,11 @@ pub fn round_2_request_inputs(
 
         input.read_line(&mut json).unwrap();
 
-        // TODO: fix error
         let randomizer = frost::round2::Randomizer::deserialize(
             &hex::decode(json.trim())
-                .map_err(|_| Error::MalformedIdentifier)?
+                .map_err(|_| Error::FieldError(FieldError::MalformedScalar))?
                 .try_into()
-                .map_err(|_| Error::MalformedIdentifier)?,
+                .map_err(|_| Error::FieldError(FieldError::MalformedScalar))?,
         )?;
         Ok(Round2Config {
             signing_package,

--- a/participant/src/round2.rs
+++ b/participant/src/round2.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "redpallas"))]
+use frost_ed25519 as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas as frost;
+
 use crate::Logger;
 use frost::{
     keys::KeyPackage,
@@ -5,12 +10,13 @@ use frost::{
     round2::{self, SignatureShare},
     Error, SigningPackage,
 };
-use frost_ed25519 as frost;
 use std::io::BufRead;
 
 // #[derive(Debug)]
 pub struct Round2Config {
     pub signing_package: SigningPackage,
+    #[cfg(feature = "redpallas")]
+    pub randomizer: frost::round2::Randomizer,
 }
 
 // TODO: refactor to generate config
@@ -31,6 +37,28 @@ pub fn round_2_request_inputs(
     let signing_package: SigningPackage = serde_json::from_str(signing_package_json.trim())
         .map_err(|_| Error::MalformedSigningKey)?;
 
+    #[cfg(feature = "redpallas")]
+    {
+        logger.log("Enter the randomizer (hex string):".to_string());
+
+        let mut json = String::new();
+
+        input.read_line(&mut json).unwrap();
+
+        // TODO: fix error
+        let randomizer = frost::round2::Randomizer::deserialize(
+            &hex::decode(json.trim())
+                .map_err(|_| Error::MalformedIdentifier)?
+                .try_into()
+                .map_err(|_| Error::MalformedIdentifier)?,
+        )?;
+        Ok(Round2Config {
+            signing_package,
+            randomizer,
+        })
+    }
+
+    #[cfg(not(feature = "redpallas"))]
     Ok(Round2Config { signing_package })
 }
 
@@ -40,7 +68,15 @@ pub fn generate_signature(
     signing_nonces: &SigningNonces,
 ) -> Result<SignatureShare, Error> {
     let signing_package = config.signing_package;
+    #[cfg(not(feature = "redpallas"))]
     let signature = round2::sign(&signing_package, signing_nonces, key_package)?;
+    #[cfg(feature = "redpallas")]
+    let signature = round2::sign(
+        &signing_package,
+        signing_nonces,
+        key_package,
+        config.randomizer,
+    )?;
     Ok(signature)
 }
 

--- a/trusted-dealer/Cargo.toml
+++ b/trusted-dealer/Cargo.toml
@@ -7,10 +7,15 @@ edition = "2021"
 
 [dependencies]
 frost-ed25519 = "0.6.0"
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "8534e283acf0015cc2450e2a6b49685a3bb3145d", features = ["frost"] }
 thiserror = "1.0"
 rand = "0.8"
 hex = "0.4"
 itertools = "0.11.0"
 exitcode = "1.1.2"
 serde_json = "1.0"
+
+[features]
+redpallas = []
+default = []
 

--- a/trusted-dealer/src/cli.rs
+++ b/trusted-dealer/src/cli.rs
@@ -1,6 +1,10 @@
+#[cfg(not(feature = "redpallas"))]
+use frost_ed25519 as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas as frost;
+
 use frost::keys::IdentifierList;
 use frost::Error;
-use frost_ed25519 as frost;
 use rand::thread_rng;
 use std::io;
 

--- a/trusted-dealer/src/inputs.rs
+++ b/trusted-dealer/src/inputs.rs
@@ -1,5 +1,9 @@
-use frost::Error;
+#[cfg(not(feature = "redpallas"))]
 use frost_ed25519 as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas as frost;
+
+use frost::Error;
 use std::io::BufRead;
 
 #[derive(Debug, PartialEq, Clone)]

--- a/trusted-dealer/src/output.rs
+++ b/trusted-dealer/src/output.rs
@@ -1,6 +1,12 @@
+#[cfg(not(feature = "redpallas"))]
+use frost_ed25519 as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas::keys::PositiveY;
+
 use frost::keys::{PublicKeyPackage, SecretShare};
 use frost::Identifier;
-use frost_ed25519 as frost;
 use itertools::Itertools;
 use std::collections::HashMap;
 
@@ -19,6 +25,11 @@ pub fn print_values(
     pubkeys: &PublicKeyPackage,
     logger: &mut dyn Logger,
 ) {
+    #[cfg(feature = "redpallas")]
+    let pubkeys = pubkeys.clone().into_positive_y();
+    #[cfg(feature = "redpallas")]
+    let pubkeys = &pubkeys;
+
     logger.log(format!(
         "Public key package:\n{}",
         serde_json::to_string(pubkeys).unwrap()

--- a/trusted-dealer/src/trusted_dealer_keygen.rs
+++ b/trusted-dealer/src/trusted_dealer_keygen.rs
@@ -1,6 +1,10 @@
+#[cfg(not(feature = "redpallas"))]
+use frost_ed25519 as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas as frost;
+
 use frost::keys::{IdentifierList, PublicKeyPackage, SecretShare};
 use frost::{Error, Identifier, SigningKey};
-use frost_ed25519 as frost;
 use rand::rngs::ThreadRng;
 use std::collections::HashMap;
 


### PR DESCRIPTION
Depends on #62 

This adds support for RedPallas using the `redpallas` feature (e.g. `cargo run --bin dkg --features redpallas`)

[Features should be additive](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification) and this goes against that, but since we have only binaries and not libraries, it seems fine.

When  `redpallas` is activate, support for rerandomized FROST is also enabled. Currently the randomizer is always read (even though ideally it should be generated by the coordinator) because this is currently required by the demo.