### PR TITLE
Fix redpallas issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,15 @@ on:
 
 jobs:
 
+  build_redpallas:
+    name: Build with redpallas
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4.1.0
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --features redpallas
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +212,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "const-crc32"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d13f542d70e5b339bf46f6f74704ac052cfd526c58cd87996bd1ef4615b9a0"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +288,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-channel"
@@ -394,10 +421,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e493c573fce17f00dcab13b6ac057994f3ce17d1af4dc39bfd482b83c6eb6157"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "errno"
@@ -482,28 +524,29 @@ dependencies = [
  "serde_json",
  "serdect",
  "thiserror",
- "visibility",
+ "visibility 0.0.1",
  "zeroize",
 ]
 
 [[package]]
 name = "frost-core"
-version = "0.6.0"
-source = "git+https://github.com/ZcashFoundation/frost.git?rev=08cbe8f591d178879c26de3672bf11f239a361fe#08cbe8f591d178879c26de3672bf11f239a361fe"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b61d737e19bea0cedda9a11dab96ab1fd1e4016f707e8ee9018d8f17d2cd18"
 dependencies = [
  "byteorder",
- "criterion",
+ "const-crc32",
  "debugless-unwrap",
  "derive-getters",
+ "document-features",
  "hex",
  "itertools 0.11.0",
- "proptest",
+ "postcard",
  "rand_core",
  "serde",
- "serde_json",
  "serdect",
  "thiserror",
- "visibility",
+ "visibility 0.1.0",
  "zeroize",
 ]
 
@@ -514,18 +557,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c69d652160d8031e2cf2b57d9e9320cf5b5ba2be18081511411d6355df87f3d1"
 dependencies = [
  "curve25519-dalek",
- "frost-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frost-core 0.6.0",
  "rand_core",
  "sha2",
 ]
 
 [[package]]
 name = "frost-rerandomized"
-version = "0.6.0"
-source = "git+https://github.com/ZcashFoundation/frost.git?rev=08cbe8f591d178879c26de3672bf11f239a361fe#08cbe8f591d178879c26de3672bf11f239a361fe"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b45409d93cf5000f52ae64847a8a270a4562f1a035e74c3fae0e2462adb97ae"
 dependencies = [
  "derive-getters",
- "frost-core 0.6.0 (git+https://github.com/ZcashFoundation/frost.git?rev=08cbe8f591d178879c26de3672bf11f239a361fe)",
+ "document-features",
+ "frost-core 0.7.0",
  "rand_core",
 ]
 
@@ -572,6 +617,29 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -675,6 +743,22 @@ name = "linux-raw-sys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+
+[[package]]
+name = "litrs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9275e0933cf8bb20f008924c0cb07a0692fe54d8064996520bf998de9eb79aa"
+
+[[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -798,6 +882,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+dependencies = [
+ "cobs",
+ "embedded-io",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "reddsa"
 version = "0.5.1"
-source = "git+https://github.com/ZcashFoundation/reddsa.git?rev=8534e283acf0015cc2450e2a6b49685a3bb3145d#8534e283acf0015cc2450e2a6b49685a3bb3145d"
+source = "git+https://github.com/ZcashFoundation/reddsa.git?rev=5ea1293bb8df90c8a19dedf7ab5510903650dda9#5ea1293bb8df90c8a19dedf7ab5510903650dda9"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1090,6 +1186,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1346,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "visibility"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3fd98999db9227cf28e59d83e1f120f42bc233d4b152e8fab9bc87d5bb1e0f8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ default-members = ["participant",
     "trusted-dealer",
     "dkg",
     "coordinator", "tests"]
-
+resolver = "2"

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 eyre = "0.6.8"
 frost-ed25519 = { version = "0.6.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "8534e283acf0015cc2450e2a6b49685a3bb3145d", features = ["frost"] }
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "5ea1293bb8df90c8a19dedf7ab5510903650dda9", features = ["frost"] }
 hex = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
 rand = "0.8"

--- a/dkg/Cargo.toml
+++ b/dkg/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 eyre = "0.6.8"
 frost-ed25519 = { version = "0.6.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "8534e283acf0015cc2450e2a6b49685a3bb3145d", features = ["frost"] }
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "5ea1293bb8df90c8a19dedf7ab5510903650dda9", features = ["frost"] }
 hex = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
 rand = "0.8"

--- a/participant/Cargo.toml
+++ b/participant/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 frost-ed25519 = { version = "0.6.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "8534e283acf0015cc2450e2a6b49685a3bb3145d", features = ["frost"] }
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "5ea1293bb8df90c8a19dedf7ab5510903650dda9", features = ["frost"] }
 hex = "0.4"
 rand = "0.8"
 exitcode = "1.1.2"

--- a/participant/src/round2.rs
+++ b/participant/src/round2.rs
@@ -13,7 +13,7 @@ use frost::{
 };
 use std::io::{BufRead, Write};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Round2Config {
     pub signing_package: SigningPackage,
     #[cfg(feature = "redpallas")]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 frost-ed25519 = { version = "0.6.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "8534e283acf0015cc2450e2a6b49685a3bb3145d", features = ["frost"] }
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "5ea1293bb8df90c8a19dedf7ab5510903650dda9", features = ["frost"] }
 hex = "0.4"
 rand = "0.8"
 exitcode = "1.1.2"

--- a/trusted-dealer/Cargo.toml
+++ b/trusted-dealer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 frost-ed25519 = { version = "0.6.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "8534e283acf0015cc2450e2a6b49685a3bb3145d", features = ["frost"] }
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "5ea1293bb8df90c8a19dedf7ab5510903650dda9", features = ["frost"] }
 thiserror = "1.0"
 rand = "0.8"
 hex = "0.4"

--- a/trusted-dealer/src/inputs.rs
+++ b/trusted-dealer/src/inputs.rs
@@ -2,6 +2,8 @@
 use frost_ed25519 as frost;
 #[cfg(feature = "redpallas")]
 use reddsa::frost::redpallas as frost;
+#[cfg(feature = "redpallas")]
+use reddsa::frost::redpallas::keys::PositiveY;
 
 use frost::keys::{PublicKeyPackage, SecretShare};
 use frost::Error;


### PR DESCRIPTION
- Fix compiling issues with redpallas feature
- Update reddsa to point to main (later we can make a new reddsa release after frost 1.0.0-rc.0 is released, and point to that)
- Add redpallas build to CI to make sure it doesn't get broken again