### PR TITLE
Phase 1 cleanup

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,16 +10,13 @@ on:
 
 jobs:
 
-  # We're using nightly for the async traits.
-  # TODO: Revert back to stable when that is stabilized.
-
   test_ed25519:
     name: Test with ed25519
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
 
   test_redpallas:
@@ -28,7 +25,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --features redpallas
 
   clippy:
@@ -39,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - name: Run clippy manually without annotations
@@ -53,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "async-trait"
+version = "0.1.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +283,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 name = "coordinator"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "clap",
  "exitcode",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,7 @@ dependencies = [
 name = "participant"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "clap",
  "exitcode",
  "eyre",

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.77"
 eyre = "0.6.11"
 frost-ed25519 = { version = "1.0.0-rc.0", features = ["serde"] }
 reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "81c649c412e5b6ba56d491d2857f91fbd28adbc7", features = ["frost", "serde"] }
@@ -21,5 +22,4 @@ message-io = "0.18"
 
 [features]
 redpallas = []
-sockets = []
 default = []

--- a/coordinator/src/args.rs
+++ b/coordinator/src/args.rs
@@ -3,6 +3,12 @@ use clap::Parser;
 #[derive(Parser, Debug, Default)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    /// CLI mode. If enabled, it will prompt for inputs from stdin
+    /// and print values to stdout, ignoring other flags.
+    /// If false, socket communication is enabled.
+    #[arg(long, default_value_t = false)]
+    pub cli: bool,
+
     /// The number of participants. If 0, will prompt for a value.
     #[arg(short = 'n', long, default_value_t = 0)]
     pub num_signers: u16,

--- a/coordinator/src/comms.rs
+++ b/coordinator/src/comms.rs
@@ -6,18 +6,20 @@ use frost_ed25519 as frost;
 #[cfg(feature = "redpallas")]
 use reddsa::frost::redpallas as frost;
 
+use std::{
+    collections::BTreeMap,
+    error::Error,
+    io::{BufRead, Write},
+};
+
+use async_trait::async_trait;
+
 use frost::{
     keys::PublicKeyPackage,
     round1::SigningCommitments,
     round2::SignatureShare,
     serde::{self, Deserialize, Serialize},
     Identifier, SigningPackage,
-};
-
-use std::{
-    collections::BTreeMap,
-    error::Error,
-    io::{BufRead, Write},
 };
 
 #[derive(Serialize, Deserialize)]
@@ -32,7 +34,7 @@ pub enum Message {
     SignatureShare(SignatureShare),
 }
 
-#[allow(async_fn_in_trait)]
+#[async_trait(?Send)]
 pub trait Comms {
     async fn get_signing_commitments(
         &mut self,

--- a/coordinator/src/comms/cli.rs
+++ b/coordinator/src/comms/cli.rs
@@ -7,6 +7,8 @@ use reddsa::frost::redpallas as frost;
 
 use eyre::eyre;
 
+use async_trait::async_trait;
+
 use frost::{
     keys::PublicKeyPackage, round1::SigningCommitments, round2::SignatureShare, Identifier,
     SigningPackage,
@@ -22,6 +24,7 @@ use super::Comms;
 
 pub struct CLIComms {}
 
+#[async_trait(?Send)]
 impl Comms for CLIComms {
     async fn get_signing_commitments(
         &mut self,

--- a/coordinator/src/comms/socket.rs
+++ b/coordinator/src/comms/socket.rs
@@ -1,5 +1,6 @@
 //! Socket implementation of the Comms trait, using message-io.
 
+use async_trait::async_trait;
 #[cfg(not(feature = "redpallas"))]
 use frost_ed25519 as frost;
 #[cfg(feature = "redpallas")]
@@ -71,6 +72,7 @@ impl SocketComms {
     }
 }
 
+#[async_trait(?Send)]
 impl Comms for SocketComms {
     async fn get_signing_commitments(
         &mut self,

--- a/coordinator/src/step_1.rs
+++ b/coordinator/src/step_1.rs
@@ -21,7 +21,7 @@ pub struct ParticipantsConfig {
 // TODO: needs to include the coordinator's keys!
 pub async fn step_1(
     args: &Args,
-    comms: &mut impl Comms,
+    comms: &mut dyn Comms,
     reader: &mut dyn BufRead,
     logger: &mut dyn Write,
 ) -> Result<ParticipantsConfig, Box<dyn std::error::Error>> {
@@ -38,7 +38,7 @@ pub async fn step_1(
 // 3. identifiers for all participants
 async fn read_commitments(
     args: &Args,
-    comms: &mut impl Comms,
+    comms: &mut dyn Comms,
     input: &mut dyn BufRead,
     logger: &mut dyn Write,
 ) -> Result<ParticipantsConfig, Box<dyn std::error::Error>> {
@@ -50,7 +50,7 @@ async fn read_commitments(
     )?;
     let pub_key_package: PublicKeyPackage = serde_json::from_str(&pub_key_package)?;
 
-    let num_of_participants = if args.num_signers == 0 {
+    let num_of_participants = if args.cli && args.num_signers == 0 {
         writeln!(logger, "The number of participants: ")?;
 
         let mut participants = String::new();

--- a/coordinator/src/step_2.rs
+++ b/coordinator/src/step_2.rs
@@ -38,7 +38,7 @@ fn request_message(
     logger: &mut dyn Write,
     commitments: BTreeMap<Identifier, SigningCommitments>,
 ) -> Result<SigningPackage, Box<dyn std::error::Error>> {
-    let message = if args.message == "-" {
+    let message = if args.cli && args.message == "-" {
         writeln!(logger, "The message to be signed (hex encoded)")?;
 
         let mut msg = String::new();

--- a/coordinator/src/step_3.rs
+++ b/coordinator/src/step_3.rs
@@ -31,7 +31,7 @@ pub fn request_randomizer(
 
 pub async fn step_3(
     args: &Args,
-    comms: &mut impl Comms,
+    comms: &mut dyn Comms,
     input: &mut dyn BufRead,
     logger: &mut dyn Write,
     participants: ParticipantsConfig,
@@ -56,7 +56,7 @@ pub async fn step_3(
 // 1. number of signers (TODO: maybe pass this in?)
 // 2. signatures for all signers
 async fn request_inputs_signature_shares(
-    comms: &mut impl Comms,
+    comms: &mut dyn Comms,
     input: &mut dyn BufRead,
     logger: &mut dyn Write,
     participants: ParticipantsConfig,

--- a/participant/Cargo.toml
+++ b/participant/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.77"
 frost-ed25519 = { version = "1.0.0-rc.0", features = ["serde"] }
 reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "81c649c412e5b6ba56d491d2857f91fbd28adbc7", features = ["frost"] }
 hex = "0.4"
@@ -19,5 +20,4 @@ message-io = "0.18"
 
 [features]
 redpallas = []
-sockets = []
 default = []

--- a/participant/src/args.rs
+++ b/participant/src/args.rs
@@ -3,6 +3,12 @@ use clap::Parser;
 #[derive(Parser, Debug, Default)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    /// CLI mode. If enabled, it will prompt for inputs from stdin
+    /// and print values to stdout, ignoring other flags.
+    /// If false, socket communication is enabled.
+    #[arg(long, default_value_t = false)]
+    pub cli: bool,
+
     /// Public key package to use. Can be a file with a JSON-encoded
     /// package, or "-". If the file does not exist or if "-" is specified,
     /// then it will be read from standard input.

--- a/participant/src/comms.rs
+++ b/participant/src/comms.rs
@@ -1,6 +1,8 @@
 pub mod cli;
 pub mod socket;
 
+use async_trait::async_trait;
+
 #[cfg(not(feature = "redpallas"))]
 use frost_ed25519 as frost;
 #[cfg(feature = "redpallas")]
@@ -30,7 +32,7 @@ pub enum Message {
     SignatureShare(SignatureShare),
 }
 
-#[allow(async_fn_in_trait)]
+#[async_trait(?Send)]
 pub trait Comms {
     async fn get_signing_package(
         &mut self,

--- a/participant/src/comms/cli.rs
+++ b/participant/src/comms/cli.rs
@@ -1,5 +1,6 @@
 //! Command line interface implementation of the Comms trait.
 
+use async_trait::async_trait;
 #[cfg(not(feature = "redpallas"))]
 use frost_ed25519 as frost;
 #[cfg(feature = "redpallas")]
@@ -22,6 +23,7 @@ use crate::comms::Comms;
 
 pub struct CLIComms {}
 
+#[async_trait(?Send)]
 impl Comms for CLIComms {
     async fn get_signing_package(
         &mut self,

--- a/participant/src/comms/socket.rs
+++ b/participant/src/comms/socket.rs
@@ -1,5 +1,6 @@
 //! Socket implementation of the Comms trait, using message-io.
 
+use async_trait::async_trait;
 #[cfg(not(feature = "redpallas"))]
 use frost_ed25519 as frost;
 #[cfg(feature = "redpallas")]
@@ -74,6 +75,7 @@ impl SocketComms {
     }
 }
 
+#[async_trait(?Send)]
 impl Comms for SocketComms {
     async fn get_signing_package(
         &mut self,

--- a/participant/src/round2.rs
+++ b/participant/src/round2.rs
@@ -24,7 +24,7 @@ pub struct Round2Config {
 // TODO: refactor to generate config
 // TODO: handle errors
 pub async fn round_2_request_inputs(
-    comms: &mut impl Comms,
+    comms: &mut dyn Comms,
     input: &mut impl BufRead,
     logger: &mut dyn Write,
     commitments: SigningCommitments,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"

--- a/trusted-dealer/src/args.rs
+++ b/trusted-dealer/src/args.rs
@@ -3,9 +3,10 @@ use clap::Parser;
 #[derive(Parser, Debug, Default)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
-    /// CLI mode. If enabled, it will prompts for inputs from stdin
+    /// CLI mode. If enabled, it will prompt for inputs from stdin
     /// and print values to stdout, ignoring other flags.
-    #[arg(short = 'i', long, default_value_t = false)]
+    /// If false, socket communication is enabled.
+    #[arg(long, default_value_t = false)]
     pub cli: bool,
 
     /// Where to write the public key package to use. Can be a file path or "-".


### PR DESCRIPTION
- Remove sockets feature, allow switching implementations at runtime. Added `--cli` to specify the old CLI mode.
- Use the `async-trait` crate instead of the nightly async trait support. This is because the latter is [still not sufficient for us due to lack of dynamic dispatch](https://stackoverflow.com/a/77320894/359009) 