### PR TITLE
Phase 1: also send randomizer

### DIFF
--- a/coordinator/src/args.rs
+++ b/coordinator/src/args.rs
@@ -24,6 +24,12 @@ pub struct Args {
     #[arg(short = 'm', long, default_value = "-")]
     pub message: String,
 
+    /// The randomizer to use. Can be a file with the raw randomizer, or "-". If "-"
+    /// is specified, then it will be read from standard input as a hex string.
+    #[cfg(feature = "redpallas")]
+    #[arg(short = 'r', long, default_value = "-")]
+    pub randomizer: String,
+
     /// Where to write the generated raw bytes signature. If "-", the
     /// human-readable hex-string is printed to stdout.
     #[arg(short = 's', long, default_value = "-")]

--- a/coordinator/src/cli.rs
+++ b/coordinator/src/cli.rs
@@ -40,7 +40,7 @@ pub async fn cli(
     .await?;
 
     #[cfg(feature = "redpallas")]
-    let randomizer = request_randomizer(reader, logger)?;
+    let randomizer = request_randomizer(args, reader, logger)?;
 
     writeln!(logger, "=== STEP 3: BUILD GROUP SIGNATURE ===\n")?;
 

--- a/coordinator/src/comms.rs
+++ b/coordinator/src/comms.rs
@@ -30,7 +30,13 @@ pub enum Message {
         identifier: Identifier,
         commitments: SigningCommitments,
     },
+    #[cfg(not(feature = "redpallas"))]
     SigningPackage(SigningPackage),
+    #[cfg(feature = "redpallas")]
+    SigningPackageAndRandomizer {
+        signing_package: SigningPackage,
+        randomizer: frost::round2::Randomizer,
+    },
     SignatureShare(SignatureShare),
 }
 

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -13,12 +13,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut reader = Box::new(io::stdin().lock());
     let mut logger = io::stdout();
-    cli(&args, &mut reader, &mut logger).await?;
+    let r = cli(&args, &mut reader, &mut logger).await;
 
     // Force process to exit; since socket comms spawn a thread, it will keep
     // running forever. Ideally we should join() the thread but this works for
     // now.
-    std::process::exit(0);
+    match r {
+        Ok(_) => std::process::exit(0),
+        Err(e) => {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
+    }
 }
 
 // Choose participants -> send message to those participants - gen message to send

--- a/coordinator/src/step_1.rs
+++ b/coordinator/src/step_1.rs
@@ -50,7 +50,7 @@ async fn read_commitments(
     )?;
     let pub_key_package: PublicKeyPackage = serde_json::from_str(&pub_key_package)?;
 
-    let num_of_participants = if args.cli && args.num_signers == 0 {
+    let num_of_participants = if args.num_signers == 0 {
         writeln!(logger, "The number of participants: ")?;
 
         let mut participants = String::new();

--- a/coordinator/src/step_2.rs
+++ b/coordinator/src/step_2.rs
@@ -38,7 +38,7 @@ fn request_message(
     logger: &mut dyn Write,
     commitments: BTreeMap<Identifier, SigningCommitments>,
 ) -> Result<SigningPackage, Box<dyn std::error::Error>> {
-    let message = if args.cli && args.message == "-" {
+    let message = if args.message == "-" {
         writeln!(logger, "The message to be signed (hex encoded)")?;
 
         let mut msg = String::new();
@@ -46,6 +46,7 @@ fn request_message(
 
         hex::decode(msg.trim())?
     } else {
+        eprintln!("Reading message from {}...", &args.message);
         fs::read(&args.message)?
     };
 

--- a/participant/src/args.rs
+++ b/participant/src/args.rs
@@ -15,11 +15,11 @@ pub struct Args {
     #[arg(short = 'k', long, default_value = "key-package-1.json")]
     pub key_package: String,
 
-    /// IP to bind to, if using online comms
-    #[arg(short, long, default_value = "0.0.0.0")]
+    /// IP to connect to, if using online comms
+    #[arg(short, long, default_value = "127.0.0.1")]
     pub ip: String,
 
-    /// Port to bind to, if using online comms
+    /// Port to connect to, if using online comms
     #[arg(short, long, default_value_t = 2744)]
     pub port: u16,
 }

--- a/participant/src/main.rs
+++ b/participant/src/main.rs
@@ -13,10 +13,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     let mut reader = Box::new(io::stdin().lock());
     let mut logger = io::stdout();
-    cli(&args, &mut reader, &mut logger).await?;
+    let r = cli(&args, &mut reader, &mut logger).await;
 
     // Force process to exit; since socket comms spawn a thread, it will keep
     // running forever. Ideally we should join() the thread but this works for
     // now.
-    std::process::exit(0);
+    match r {
+        Ok(_) => std::process::exit(0),
+        Err(e) => {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
+    }
 }


### PR DESCRIPTION
Depends on #138 .

I also changed a bit the semantic of the `cli` flag. After thinking about it, I think it makes more sense for it to control only whether to use sockets comms or CLI "comms" and not how inputs to the program are read. So now it should be possible to e.g. read the message from the CLI even if socket comms are used, if the user wishes to.