### PR TITLE
Phase 2: add server logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive-getters"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,6 +1887,7 @@ dependencies = [
  "axum",
  "axum-test",
  "clap",
+ "derivative",
  "eyre",
  "rand",
  "reddsa",
@@ -1883,6 +1895,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2233,6 +2246,23 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da193277a4e2c33e59e09b5861580c33dd0a637c3883d0fa74ba40c0374af2e"
+dependencies = [
+ "bitflags 2.4.2",
+ "bytes",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 axum = "0.7.3"
 clap = { version = "4.4.14", features = ["derive"] }
+derivative = "2.2.0"
 eyre = "0.6.11"
 rand = "0.8"
 reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "81c649c412e5b6ba56d491d2857f91fbd28adbc7", features = [
@@ -17,6 +18,7 @@ reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "81c649c
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
 tokio = { version = "1.0", features = ["full"] }
+tower-http = { version = "0.5.1", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.6.1", features = ["v4", "fast-rng", "serde"] }

--- a/server/src/functions.rs
+++ b/server/src/functions.rs
@@ -12,10 +12,12 @@ use crate::{
 };
 
 /// Implement the create_new_session API.
+#[tracing::instrument(ret, err(Debug))]
 pub(crate) async fn create_new_session(
     State(state): State<SharedState>,
     Json(args): Json<CreateNewSessionArgs>,
 ) -> Result<Json<CreateNewSessionOutput>, AppError> {
+    tracing::info!("create_new_session");
     if args.message_count == 0 {
         return Err(AppError(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -38,6 +40,7 @@ pub(crate) async fn create_new_session(
 }
 
 /// Implement the get_session_info API
+#[tracing::instrument(ret, err(Debug))]
 pub(crate) async fn get_session_info(
     State(state): State<SharedState>,
     Json(args): Json<GetSessionInfoArgs>,
@@ -57,6 +60,7 @@ pub(crate) async fn get_session_info(
 
 /// Implement the send_commitments API
 // TODO: get identifier from channel rather from arguments
+#[tracing::instrument(ret, err(Debug))]
 pub(crate) async fn send_commitments(
     State(state): State<SharedState>,
     Json(args): Json<SendCommitmentsArgs>,
@@ -103,6 +107,7 @@ pub(crate) async fn send_commitments(
 }
 
 /// Implement the get_commitments API
+#[tracing::instrument(ret, err(Debug))]
 pub(crate) async fn get_commitments(
     State(state): State<SharedState>,
     Json(args): Json<GetCommitmentsArgs>,
@@ -136,6 +141,7 @@ pub(crate) async fn get_commitments(
 }
 
 /// Implement the send_signing_package API
+#[tracing::instrument(ret, err(Debug))]
 pub(crate) async fn send_signing_package(
     State(state): State<SharedState>,
     Json(args): Json<SendSigningPackageArgs>,
@@ -179,6 +185,7 @@ pub(crate) async fn send_signing_package(
 }
 
 /// Implement the get_signing_package API
+#[tracing::instrument(ret, err(Debug))]
 pub(crate) async fn get_signing_package(
     State(state): State<SharedState>,
     Json(args): Json<GetSigningPackageArgs>,
@@ -211,6 +218,7 @@ pub(crate) async fn get_signing_package(
 
 /// Implement the send_signature_share API
 // TODO: get identifier from channel rather from arguments
+#[tracing::instrument(ret, err(Debug))]
 pub(crate) async fn send_signature_share(
     State(state): State<SharedState>,
     Json(args): Json<SendSignatureShareArgs>,
@@ -264,6 +272,7 @@ pub(crate) async fn send_signature_share(
 }
 
 /// Implement the get_signature_shares API
+#[tracing::instrument(ret, err(Debug))]
 pub(crate) async fn get_signature_shares(
     State(state): State<SharedState>,
     Json(args): Json<GetSignatureSharesArgs>,
@@ -299,6 +308,7 @@ pub(crate) async fn get_signature_shares(
 }
 
 /// Implement the close_session API.
+#[tracing::instrument(ret, err(Debug))]
 pub(crate) async fn close_session(
     State(state): State<SharedState>,
     Json(args): Json<CloseSessionArgs>,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod args;
 mod functions;
 mod state;
 mod types;
+use tower_http::trace::TraceLayer;
 pub use types::*;
 
 use args::Args;
@@ -37,6 +38,7 @@ pub fn router() -> Router {
             post(functions::get_signature_shares),
         )
         .route("/close_session", post(functions::close_session))
+        .layer(TraceLayer::new_for_http())
         .with_state(shared_state)
 }
 
@@ -52,6 +54,7 @@ pub async fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
 /// An error. Wraps a StatusCode which is returned by the server when the
 /// error happens during a API call, and a generic eyre::Report.
 // TODO: create an enum with specific errors
+#[derive(Debug)]
 pub struct AppError(StatusCode, eyre::Report);
 
 impl IntoResponse for AppError {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -7,5 +7,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     // initialize tracing
     tracing_subscriber::fmt::init();
+    tracing::event!(tracing::Level::INFO, "server running");
     run(&args).await
 }

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -8,6 +8,8 @@ use uuid::Uuid;
 use reddsa::frost::redpallas as frost;
 
 /// The current state of the server, and the required data for the state.
+#[derive(derivative::Derivative)]
+#[derivative(Debug)]
 pub enum SessionState {
     /// Waiting for participants to send their commitments.
     WaitingForCommitments {
@@ -33,6 +35,7 @@ pub enum SessionState {
         /// Randomizer sent by coordinator to be sent to participants, for each
         /// message being signed.
         /// (Rerandomized FROST only. TODO: make it optional?)
+        #[derivative(Debug = "ignore")]
         randomizer: Vec<frost::round2::Randomizer>,
         /// Auxiliary (optional) message. A context-specific data that is
         /// supposed to be interpreted by the participants.
@@ -58,6 +61,7 @@ impl Default for SessionState {
 }
 
 /// A particular signing session.
+#[derive(Debug)]
 pub struct Session {
     /// The number of signers in the session.
     pub(crate) num_signers: u16,
@@ -70,7 +74,7 @@ pub struct Session {
 }
 
 /// The global state of the server.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AppState {
     /// Mapping of signing sessions by UUID.
     pub(crate) sessions: HashMap<Uuid, Session>,

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -5,83 +5,87 @@ use uuid::Uuid;
 
 use reddsa::frost::redpallas as frost;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreateNewSessionArgs {
     pub num_signers: u16,
     pub message_count: u8,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreateNewSessionOutput {
     pub session_id: Uuid,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetSessionInfoArgs {
     pub session_id: Uuid,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetSessionInfoOutput {
     pub num_signers: u16,
     pub message_count: u8,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SendCommitmentsArgs {
     pub session_id: Uuid,
     pub identifier: frost::Identifier,
     pub commitments: Vec<frost::round1::SigningCommitments>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetCommitmentsArgs {
     pub session_id: Uuid,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetCommitmentsOutput {
     pub commitments: Vec<BTreeMap<frost::Identifier, frost::round1::SigningCommitments>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, derivative::Derivative)]
+#[derivative(Debug)]
 pub struct SendSigningPackageArgs {
     pub session_id: Uuid,
     pub signing_package: Vec<frost::SigningPackage>,
     pub aux_msg: Vec<u8>,
+    #[derivative(Debug = "ignore")]
     pub randomizer: Vec<frost::round2::Randomizer>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetSigningPackageArgs {
     pub session_id: Uuid,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, derivative::Derivative)]
+#[derivative(Debug)]
 pub struct GetSigningPackageOutput {
     pub signing_package: Vec<frost::SigningPackage>,
+    #[derivative(Debug = "ignore")]
     pub randomizer: Vec<frost::round2::Randomizer>,
     pub aux_msg: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SendSignatureShareArgs {
     pub session_id: Uuid,
     pub identifier: frost::Identifier,
     pub signature_share: Vec<frost::round2::SignatureShare>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetSignatureSharesArgs {
     pub session_id: Uuid,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetSignatureSharesOutput {
     pub signature_shares: Vec<BTreeMap<frost::Identifier, frost::round2::SignatureShare>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CloseSessionArgs {
     pub session_id: Uuid,
 }


### PR DESCRIPTION
Based on #147 

To use it, prefix commands with `RUST_LOG=debug` e.g. `RUST_LOG=debug cargo run...`