### PR TITLE
frost-client: add encryption and authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,7 @@ dependencies = [
  "hex",
  "itertools",
  "message-io",
+ "participant",
  "rand",
  "reddsa",
  "reqwest",
@@ -610,6 +611,7 @@ dependencies = [
  "serde_json",
  "serdect",
  "server",
+ "snow",
  "thiserror",
  "tokio",
 ]
@@ -1027,6 +1029,7 @@ dependencies = [
  "frost-ed25519",
  "frost-rerandomized",
  "hex",
+ "itertools",
  "participant",
  "postcard",
  "rand",
@@ -1999,6 +2002,7 @@ dependencies = [
  "serde_json",
  "serdect",
  "server",
+ "snow",
  "tokio",
 ]
 

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -23,9 +23,11 @@ exitcode = "1.1.2"
 clap = { version = "4.5.20", features = ["derive"] }
 reqwest = { version = "0.12.8", features = ["json"] }
 server = { path = "../server" }
+participant = { path = "../participant" }
 tokio = { version = "1", features = ["full"] }
 message-io = "0.18"
 rpassword = "7.3.1"
+snow = "0.9.6"
 
 [features]
 default = []

--- a/frost-client/Cargo.toml
+++ b/frost-client/Cargo.toml
@@ -30,3 +30,4 @@ frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
 reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost"] }
 rand = "0.8"
 stable-eyre = "0.2"
+itertools = "0.13.0"

--- a/frost-client/src/args.rs
+++ b/frost-client/src/args.rs
@@ -83,9 +83,18 @@ pub(crate) enum Command {
         /// dealer process via the FROST server (TODO: this is not supported yet)
         #[arg(short, long)]
         config: Vec<String>,
-        /// The name of each participant.
+        /// The comma-separated name of each participant.
         #[arg(short = 'N', long, value_delimiter = ',')]
         names: Vec<String>,
+        /// The comma-separated username of each participant in the same order
+        /// as `names`. Note: these won't be checked in the server.
+        #[arg(short, long, value_delimiter = ',')]
+        usernames: Vec<String>,
+        /// The server URL, if desired. Note that this does not connect to the
+        /// server; it will just associated the server URL with the group in the
+        /// config file.
+        #[arg(short, long)]
+        server_url: Option<String>,
         #[arg(short = 'C', long, default_value = "ed25519")]
         ciphersuite: String,
         /// The threshold (minimum number of signers).
@@ -107,11 +116,11 @@ pub(crate) enum Command {
         /// $HOME/.local/frost/credentials.toml
         #[arg(short, long)]
         config: Option<String>,
-        /// The server URL to use. You can use a substring of the URL. It will
-        /// use the username previously logged in via the `login` subcommand for
-        /// the given server.
+        /// The server URL to use. If not specified, it will use the server URL
+        /// for the specified group, if any. It will use the username previously
+        /// logged in via the `login` subcommand for the given server.
         #[arg(short, long)]
-        server_url: String,
+        server_url: Option<String>,
         /// The group to use, identified by the group public key (use `groups`
         /// to list)
         #[arg(short, long)]
@@ -142,11 +151,11 @@ pub(crate) enum Command {
         /// $HOME/.local/frost/credentials.toml
         #[arg(short, long)]
         config: Option<String>,
-        /// The server URL to use. You can use a substring of the URL. It will
-        /// use the username previously logged in via the `login` subcommand for
-        /// the given server.
+        /// The server URL to use. If not specified, it will use the server URL
+        /// for the specified group, if any. It will use the username previously
+        /// logged in via the `login` subcommand for the given server.
         #[arg(short, long)]
-        server_url: String,
+        server_url: Option<String>,
         /// The group to use, identified by the group public key (use `groups`
         /// to list)
         #[arg(short, long)]

--- a/frost-client/src/participant.rs
+++ b/frost-client/src/participant.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::rc::Rc;
 
 use eyre::eyre;
 use eyre::Context;
@@ -53,6 +54,8 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
     let mut input = Box::new(std::io::stdin().lock());
     let mut output = std::io::stdout();
 
+    let server_url =
+        server_url.unwrap_or(group.server_url.clone().ok_or_eyre("server-url required")?);
     let server_url_parsed =
         Url::parse(&format!("http://{}", server_url)).wrap_err("error parsing server-url")?;
 
@@ -61,6 +64,7 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
         .get(&server_url)
         .ok_or_eyre("Not registered in the given server")?;
 
+    let group_participants = group.participant.clone();
     let pargs = participant::args::ProcessedArgs {
         cli: false,
         http: true,
@@ -79,6 +83,19 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
                 .ok_or_eyre("Not logged in in the given server")?,
         ),
         session_id: String::new(),
+        comm_privkey: Some(
+            config
+                .communication_key
+                .ok_or_eyre("user not initialized")?
+                .privkey
+                .clone(),
+        ),
+        comm_coordinator_pubkey_getter: Some(Rc::new(move |coordinator_username| {
+            group_participants
+                .values()
+                .find(|p| p.username == Some(coordinator_username.to_string()))
+                .map(|p| p.pubkey.clone())
+        })),
     };
 
     cli_for_processed_args(pargs, &mut input, &mut output).await?;

--- a/participant/Cargo.toml
+++ b/participant/Cargo.toml
@@ -24,6 +24,7 @@ message-io = "0.18"
 reqwest = { version = "0.12.8", features = ["json"] }
 server = { path = "../server" }
 rpassword = "7.3.1"
+snow = "0.9.6"
 
 [features]
 default = []

--- a/server/tests/integration_tests.rs
+++ b/server/tests/integration_tests.rs
@@ -464,6 +464,8 @@ fn test_snow() -> Result<(), Box<dyn Error>> {
         .build_initiator()
         .unwrap();
 
+    println!("{}", anoise.is_handshake_finished());
+
     let mut encrypted = [0u8; 65535];
     let len = anoise
         .write_message("hello world".as_bytes(), &mut encrypted)
@@ -481,6 +483,22 @@ fn test_snow() -> Result<(), Box<dyn Error>> {
     let len = bnoise.read_message(encrypted, &mut decrypted).unwrap();
     let decrypted = &decrypted[0..len];
 
+    let mut anoise = anoise.into_transport_mode()?;
+    let mut bnoise = bnoise.into_transport_mode()?;
+
     println!("{}", str::from_utf8(decrypted).unwrap());
+
+    let mut encrypted = [0u8; 65535];
+    let len = anoise
+        .write_message("hello world".as_bytes(), &mut encrypted)
+        .unwrap();
+    let encrypted = &encrypted[0..len];
+
+    let mut decrypted = [0u8; 65535];
+    let len = bnoise.read_message(encrypted, &mut decrypted).unwrap();
+    let decrypted = &decrypted[0..len];
+
+    println!("{}", str::from_utf8(decrypted).unwrap());
+
     Ok(())
 }


### PR DESCRIPTION
Based on #328 

Closes #179 

With this, we finally have encryption/authentication!

My strategy was to change the ProcessedArgs struct to allow specifying some additional stuff that is only required for this. That way, the old tools keep working the same as they did before (we can decided later if we want them gone or not...). I refactored the participant and coordinator main functions so that they could be called as a library, being passed a ProcessedArgs as input.

I created a `Noise` struct (arbitrarily in the `participant` crate, which is then also imported by `coordinator`) to abstract an annoyance of the `snow` crate, which is that while it supports sending/receiving a message along with the handshake, it requires explicitly marking the handshake as finished.

This also updates the `trusted-dealer` command; when working on this I realized it made more sense to register the username information along with the group information and not with the contact information itself. Similarly, the server URL should be registered along with the group. (This means that you will need to create a new group with this PR in order to test it)

We should add **a lot** of tests to this. But let's leave that for a separate PR.

Example commands to test manually

```
RUST_LOG=debug cargo run --bin server
# Create a new group (necessary since this PR updates the trusted-dealer tool)
cargo run -p frost-client -- trusted-dealer --names Alice,Bob,Eve -c alice.toml -c bob.toml -c eve.toml -C redpallas -u alice,bob,eve -s localhost:2744
cargo run -p frost-client -- coordinator -c alice.toml --server-url localhost:2744 --group d107eb62cd393b19f661f58218bbcea48eca6bf15743e6cc7e9dfc1775599003 -S alice,bob -m msg.raw -r randomizer.raw
cargo run -p frost-client -- participant -c alice.toml --server-url localhost:2744 --group d107eb62cd393b19f661f58218bbcea48eca6bf15743e6cc7e9dfc1775599003
cargo run -p frost-client -- participant -c bob.toml --server-url localhost:2744 --group d107eb62cd393b19f661f58218bbcea48eca6bf15743e6cc7e9dfc1775599003
```