### PR TITLE
server: improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,6 +2688,7 @@ dependencies = [
  "serde_json",
  "serdect",
  "snow",
+ "thiserror 2.0.4",
  "tempfile",
  "tokio",
  "tower-http",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -31,6 +31,7 @@ uuid = { version = "1.11.0", features = ["v4", "fast-rng", "serde"] }
 xeddsa = "1.0.2"
 futures-util = "0.3.31"
 futures = "0.3.31"
+thiserror = "2.0.3"
 hex = "0.4.3"
 
 [dev-dependencies]

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -6,6 +6,12 @@ use serde::{Deserialize, Serialize};
 pub use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct Error {
+    pub code: usize,
+    pub msg: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RegisterArgs {
     pub username: String,
     pub password: String,

--- a/server/tests/integration_tests.rs
+++ b/server/tests/integration_tests.rs
@@ -496,8 +496,9 @@ async fn test_http() -> Result<(), Box<dyn std::error::Error>> {
     let session_id = r.session_id;
     println!("Session ID: {}", session_id);
 
-    // Error test
+    // Error tests
 
+    // Test if passing the wrong session ID returns an error
     let wrong_session_id = Uuid::new_v4();
     let r = client
         .post("http://127.0.0.1:2744/get_session_info")
@@ -510,6 +511,41 @@ async fn test_http() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(r.status(), reqwest::StatusCode::INTERNAL_SERVER_ERROR);
     let r = r.json::<server::Error>().await?;
     assert_eq!(r.code, server::SESSION_NOT_FOUND);
+
+    // Test if trying to close the session as a participant fails
+    // Attempt to close the session as a participant (Bob)
+    // Log in as Bob
+    let r = client
+        .post("http://127.0.0.1:2744/challenge")
+        .json(&server::ChallengeArgs {})
+        .send()
+        .await?;
+    let r = r.json::<server::ChallengeOutput>().await?;
+    let bob_challenge = r.challenge;
+    let bob_private =
+        xed25519::PrivateKey::from(&TryInto::<[u8; 32]>::try_into(bob_keypair.private).unwrap());
+    let bob_signature: [u8; 64] = bob_private.sign(bob_challenge.as_bytes(), &mut rng);
+    let r = client
+        .post("http://127.0.0.1:2744/login")
+        .json(&server::KeyLoginArgs {
+            uuid: bob_challenge,
+            pubkey: bob_keypair.public.clone(),
+            signature: bob_signature.to_vec(),
+        })
+        .send()
+        .await?;
+    let r = r.json::<server::KeyLoginOutput>().await?;
+    let bob_access_token = r.access_token;
+    // Try to close the session
+    let r = client
+        .post("http://127.0.0.1:2744/close_session")
+        .bearer_auth(bob_access_token)
+        .json(&server::CloseSessionArgs { session_id })
+        .send()
+        .await?;
+    assert_eq!(r.status(), reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+    let r = r.json::<server::Error>().await?;
+    assert_eq!(r.code, server::NOT_COORDINATOR);
 
     Ok(())
 }

--- a/server/tests/integration_tests.rs
+++ b/server/tests/integration_tests.rs
@@ -11,6 +11,7 @@ use server::{
 };
 
 use frost_core as frost;
+use uuid::Uuid;
 use xeddsa::{xed25519, Sign, Verify};
 
 #[tokio::test]
@@ -450,7 +451,7 @@ async fn test_http() -> Result<(), Box<dyn std::error::Error>> {
         .send()
         .await?;
     if r.status() != reqwest::StatusCode::OK {
-        panic!("{}", r.text().await?)
+        panic!("{:?}", r.json::<server::Error>().await?)
     }
     let r = r.json::<server::ChallengeOutput>().await?;
     let alice_challenge = r.challenge;
@@ -469,7 +470,7 @@ async fn test_http() -> Result<(), Box<dyn std::error::Error>> {
         .send()
         .await?;
     if r.status() != reqwest::StatusCode::OK {
-        panic!("{}", r.text().await?)
+        panic!("{:?}", r.json::<server::Error>().await?)
     }
     let r = r.json::<server::KeyLoginOutput>().await?;
     let access_token = r.access_token;
@@ -489,11 +490,26 @@ async fn test_http() -> Result<(), Box<dyn std::error::Error>> {
         .send()
         .await?;
     if r.status() != reqwest::StatusCode::OK {
-        panic!("{}", r.text().await?)
+        panic!("{:?}", r.json::<server::Error>().await?)
     }
     let r = r.json::<server::CreateNewSessionOutput>().await?;
     let session_id = r.session_id;
     println!("Session ID: {}", session_id);
+
+    // Error test
+
+    let wrong_session_id = Uuid::new_v4();
+    let r = client
+        .post("http://127.0.0.1:2744/get_session_info")
+        .bearer_auth(access_token)
+        .json(&server::GetSessionInfoArgs {
+            session_id: wrong_session_id,
+        })
+        .send()
+        .await?;
+    assert_eq!(r.status(), reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+    let r = r.json::<server::Error>().await?;
+    assert_eq!(r.code, server::SESSION_NOT_FOUND);
 
     Ok(())
 }


### PR DESCRIPTION
Based on #375 

Closes #374 

This basically turns `AppError` into an enum, and changes previous uses of it to use specific values.

A new public `Error` was introduced which is effectively the JSON value returned on error, and it's what client will interact with. The `AppError` is converted into `Error` in its `IntoResponse` implementation, which is used by axum when converting `AppError` into a response.

Since clients will only see the `code` and `msg` fields, I added a `const` for each error enum. We might want to allow converting an `Error` back to an `AppError` for Rust clients, but I don't think we need to worry about that for now.