### PR TITLE
frost-client: add support for group description

### DIFF
--- a/frost-client/src/args.rs
+++ b/frost-client/src/args.rs
@@ -83,6 +83,10 @@ pub(crate) enum Command {
         /// dealer process via the FROST server (TODO: this is not supported yet)
         #[arg(short, long)]
         config: Vec<String>,
+        /// A description of the group being created. Will be written to the
+        /// participant's config files and will help them identify groups.
+        #[arg(short, long)]
+        description: String,
         /// The comma-separated name of each participant.
         #[arg(short = 'N', long, value_delimiter = ',')]
         names: Vec<String>,

--- a/frost-client/src/config.rs
+++ b/frost-client/src/config.rs
@@ -80,9 +80,12 @@ pub struct CommunicationKey {
 }
 
 /// A FROST group the user belongs to.
-// TODO: add a textual name for the group?
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Group {
+    /// A human-readable description of the group to make it easier to select
+    /// groups
+    pub description: String,
+    /// The ciphersuite being used for the group
     pub ciphersuite: String,
     /// The encoded public key package for the group.
     #[serde(
@@ -90,13 +93,13 @@ pub struct Group {
         deserialize_with = "serdect::slice::deserialize_hex_or_bin_vec"
     )]
     pub public_key_package: Vec<u8>,
-    /// The user's encodede key package for the group.
+    /// The user's encoded key package for the group.
     #[serde(
         serialize_with = "serdect::slice::serialize_hex_lower_or_bin",
         deserialize_with = "serdect::slice::deserialize_hex_or_bin_vec"
     )]
     pub key_package: Vec<u8>,
-    /// The server the participants are registered in, if any.
+    /// The default server the participants are using, if any.
     pub server_url: Option<String>,
     /// The group participants, keyed by hex-encoded identifier
     pub participant: BTreeMap<String, Participant>,
@@ -109,7 +112,8 @@ impl Group {
         let helper = ciphersuite_helper(&self.ciphersuite)?;
         let info = helper.group_info(&self.key_package, &self.public_key_package)?;
         let mut s = format!(
-            "Group with public key {}\nServer URL: {}\nThreshold: {}\nParticipants: {}\n",
+            "Group \"{}\"\nPublic key {}\nServer URL: {}\nThreshold: {}\nParticipants: {}\n",
+            self.description,
             info.hex_verifying_key,
             self.server_url.clone().unwrap_or_default(),
             info.threshold,

--- a/frost-client/src/trusted_dealer.rs
+++ b/frost-client/src/trusted_dealer.rs
@@ -33,6 +33,7 @@ pub(crate) fn trusted_dealer_for_ciphersuite<C: Ciphersuite + MaybeIntoEvenY + '
 ) -> Result<(), Box<dyn Error>> {
     let Command::TrustedDealer {
         config,
+        description,
         ciphersuite: _,
         threshold,
         num_signers,
@@ -107,6 +108,7 @@ pub(crate) fn trusted_dealer_for_ciphersuite<C: Ciphersuite + MaybeIntoEvenY + '
         let key_package: KeyPackage<C> = share.clone().try_into()?;
         let group = Group {
             ciphersuite: C::ID.to_string(),
+            description: description.clone(),
             key_package: postcard::to_allocvec(&key_package)?,
             public_key_package: postcard::to_allocvec(&public_key_package)?,
             participant: participants.clone(),


### PR DESCRIPTION
Closes #378

This breaks compatibility with older configs.

I kept the group selection via public key - I think that's easier to specify than the group description; so the user will need to run `frost-client groups`, copy the public key, and use that for the other commands. I think that's acceptable for this tool, but suggestions are welcome.