### PR TITLE
frost-client: support multiple sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ dependencies = [
  "tokio",
  "toml",
  "trusted-dealer",
+ "xeddsa",
 ]
 
 [[package]]

--- a/frost-client/Cargo.toml
+++ b/frost-client/Cargo.toml
@@ -31,3 +31,4 @@ reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9c
 rand = "0.8"
 stable-eyre = "0.2"
 itertools = "0.13.0"
+xeddsa = "1.0.2"

--- a/frost-client/src/args.rs
+++ b/frost-client/src/args.rs
@@ -106,6 +106,21 @@ pub(crate) enum Command {
         #[arg(short, long)]
         group: String,
     },
+    /// Lists the active FROST signing sessions the user is in.
+    Sessions {
+        /// The path to the config file to manage. If not specified, it uses
+        /// $HOME/.local/frost/credentials.toml
+        #[arg(short, long)]
+        config: Option<String>,
+        /// The server URL to use. If `group` is specified and `server_url`
+        /// is not, it will use the server URL associated with `group` if any.
+        #[arg(short, long)]
+        server_url: Option<String>,
+        /// Optional group whose associated server URL will be used, identified
+        /// by the group public key (use `groups` to list).
+        #[arg(short, long)]
+        group: Option<String>,
+    },
     Coordinator {
         /// The path to the config file to manage. If not specified, it uses
         /// $HOME/.local/frost/credentials.toml
@@ -155,5 +170,9 @@ pub(crate) enum Command {
         /// to list)
         #[arg(short, long)]
         group: String,
+        /// The session ID to use (use `sessions` to list). Can be omitted in
+        /// case there is a single active session.
+        #[arg(short = 'S', long)]
+        session: Option<String>,
     },
 }

--- a/frost-client/src/config.rs
+++ b/frost-client/src/config.rs
@@ -98,7 +98,7 @@ impl Group {
         );
         for participant in self.participant.values() {
             let contact = config.contact_by_pubkey(&participant.pubkey)?;
-            s += &format!("\t{} ({})\n", contact.name, hex::encode(contact.pubkey));
+            s += &format!("\t{}\t({})\n", contact.name, hex::encode(contact.pubkey));
         }
         Ok(s)
     }

--- a/frost-client/src/main.rs
+++ b/frost-client/src/main.rs
@@ -6,6 +6,7 @@ pub mod coordinator;
 pub mod group;
 pub mod init;
 pub mod participant;
+pub mod session;
 pub mod trusted_dealer;
 pub mod write_atomic;
 
@@ -27,6 +28,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Command::RemoveContact { .. } => contact::remove(&args.command),
         Command::Groups { .. } => group::list(&args.command),
         Command::RemoveGroup { .. } => group::remove(&args.command),
+        Command::Sessions { .. } => session::list(&args.command).await,
         Command::TrustedDealer { .. } => trusted_dealer::trusted_dealer(&args.command),
         Command::Coordinator { .. } => crate::coordinator::run(&args.command).await,
         Command::Participant { .. } => crate::participant::run(&args.command).await,

--- a/frost-client/src/participant.rs
+++ b/frost-client/src/participant.rs
@@ -40,6 +40,7 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
         config,
         server_url,
         group,
+        session,
     } = (*args).clone()
     else {
         panic!("invalid Command");
@@ -72,7 +73,7 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
             .ok_or_eyre("host missing in URL")?
             .to_owned(),
         port: server_url_parsed.port().unwrap_or(2744),
-        session_id: String::new(),
+        session_id: session.unwrap_or_default(),
         comm_privkey: Some(
             config
                 .communication_key

--- a/frost-client/src/session.rs
+++ b/frost-client/src/session.rs
@@ -1,0 +1,131 @@
+use std::error::Error;
+
+use eyre::{eyre, OptionExt as _};
+use rand::thread_rng;
+use xeddsa::{xed25519, Sign as _};
+
+use crate::{args::Command, config::Config};
+
+pub(crate) async fn list(args: &Command) -> Result<(), Box<dyn Error>> {
+    let Command::Sessions {
+        config,
+        group,
+        server_url,
+    } = (*args).clone()
+    else {
+        panic!("invalid Command");
+    };
+
+    let config = Config::read(config)?;
+
+    let server_url = if let Some(server_url) = server_url {
+        server_url
+    } else if let Some(group) = group {
+        let group = config.group.get(&group).ok_or_eyre("Group not found")?;
+        group
+            .server_url
+            .clone()
+            .ok_or_eyre("the group specified does not have an associated server URL")?
+    } else {
+        return Err(eyre!("must specify either server_url or group").into());
+    };
+
+    let comm_privkey = config
+        .communication_key
+        .clone()
+        .ok_or_eyre("user not initialized")?
+        .privkey
+        .clone();
+    let comm_pubkey = config
+        .communication_key
+        .clone()
+        .ok_or_eyre("user not initialized")?
+        .pubkey
+        .clone();
+
+    let client = reqwest::Client::new();
+    let host_port = format!("http://{}", server_url);
+
+    let mut rng = thread_rng();
+
+    let challenge = client
+        .post(format!("{}/challenge", host_port))
+        .json(&server::ChallengeArgs {})
+        .send()
+        .await?
+        .json::<server::ChallengeOutput>()
+        .await?
+        .challenge;
+
+    let privkey = xed25519::PrivateKey::from(
+        &TryInto::<[u8; 32]>::try_into(comm_privkey.clone())
+            .map_err(|_| eyre!("invalid comm_privkey"))?,
+    );
+    let signature: [u8; 64] = privkey.sign(challenge.as_bytes(), &mut rng);
+
+    let access_token = client
+        .post(format!("{}/login", host_port))
+        .json(&server::KeyLoginArgs {
+            uuid: challenge,
+            pubkey: comm_pubkey.clone(),
+            signature: signature.to_vec(),
+        })
+        .send()
+        .await?
+        .json::<server::LoginOutput>()
+        .await?
+        .access_token
+        .to_string();
+
+    // Get session ID from server
+    let r = client
+        .post(format!("{}/list_sessions", host_port))
+        .bearer_auth(&access_token)
+        .send()
+        .await?
+        .json::<server::ListSessionsOutput>()
+        .await?;
+
+    if r.session_ids.is_empty() {
+        eprintln!("No active sessions.");
+    } else {
+        for session_id in r.session_ids {
+            let r = client
+                .post(format!("{}/get_session_info", host_port))
+                .bearer_auth(&access_token)
+                .json(&server::GetSessionInfoArgs { session_id })
+                .send()
+                .await?
+                .json::<server::GetSessionInfoOutput>()
+                .await?;
+            let coordinator = config.contact_by_pubkey(&r.coordinator_pubkey);
+            let participants: Vec<_> = r
+                .pubkeys
+                .iter()
+                .map(|pubkey| config.contact_by_pubkey(pubkey))
+                .collect();
+            eprintln!("Session with ID {}", session_id);
+            eprintln!(
+                "Coordinator: {}",
+                coordinator
+                    .map(|c| c.name)
+                    .unwrap_or("(Unknown contact)".to_string())
+            );
+            eprintln!("Signers: {}", participants.len());
+            for participant in participants {
+                if let Ok(participant) = participant {
+                    eprintln!(
+                        "\t{}\t({})",
+                        participant.name,
+                        hex::encode(participant.pubkey)
+                    );
+                } else {
+                    eprintln!("\t(Unknown contact)");
+                }
+            }
+            eprintln!();
+        }
+    }
+
+    Ok(())
+}

--- a/participant/src/comms/http.rs
+++ b/participant/src/comms/http.rs
@@ -232,7 +232,7 @@ where
                     .json::<server::ListSessionsOutput>()
                     .await?;
                 if r.session_ids.len() > 1 {
-                    return Err(eyre!("user has more than one FROST session active, which is still not supported by this tool").into());
+                    return Err(eyre!("user has more than one FROST session active; use `frost-client sessions` to list them and specify the session ID with `-S`").into());
                 } else if r.session_ids.is_empty() {
                     return Err(eyre!("User has no current sessions active. The Coordinator should either specify your username, or manually share the session ID which you can specify with --session_id").into());
                 }


### PR DESCRIPTION
Based on #179 

Closes #376 

Allows listing sessions, and specifying which session to use.

Choosing which session to use can be still confusing if e.g. there are multiple sessions with the same coordinator and participants. At the end of the day what truly matters is the message being signed, and that is only sent in round 2. I think we can ignore this for now (I don't think people will have dozens of concurrent FROST signing sessions) but we might want to revisit this issue later.