### PR TITLE
server: misc cleanups

### DIFF
--- a/coordinator/src/args.rs
+++ b/coordinator/src/args.rs
@@ -70,7 +70,7 @@ pub struct Args {
 
     /// Port to bind to, if using socket comms.
     /// Port to connect to, if using HTTP mode.
-    #[arg(short, long, default_value_t = 2744)]
+    #[arg(short, long, default_value_t = 443)]
     pub port: u16,
 }
 

--- a/frost-client/src/session.rs
+++ b/frost-client/src/session.rs
@@ -66,7 +66,7 @@ pub(crate) async fn list(args: &Command) -> Result<(), Box<dyn Error>> {
     let access_token = client
         .post(format!("{}/login", host_port))
         .json(&server::KeyLoginArgs {
-            uuid: challenge,
+            challenge,
             pubkey: comm_pubkey.clone(),
             signature: signature.to_vec(),
         })
@@ -102,7 +102,7 @@ pub(crate) async fn list(args: &Command) -> Result<(), Box<dyn Error>> {
             let participants: Vec<_> = r
                 .pubkeys
                 .iter()
-                .map(|pubkey| config.contact_by_pubkey(pubkey))
+                .map(|pubkey| config.contact_by_pubkey(&pubkey.0))
                 .collect();
             eprintln!("Session with ID {}", session_id);
             eprintln!(

--- a/participant/src/args.rs
+++ b/participant/src/args.rs
@@ -37,7 +37,7 @@ pub struct Args {
     pub ip: String,
 
     /// Port to connect to, if using online comms
-    #[arg(short, long, default_value_t = 2744)]
+    #[arg(short, long, default_value_t = 443)]
     pub port: u16,
 
     /// Optional Session ID

--- a/participant/src/comms/http.rs
+++ b/participant/src/comms/http.rs
@@ -203,7 +203,7 @@ where
             self.client
                 .post(format!("{}/login", self.host_port))
                 .json(&server::KeyLoginArgs {
-                    uuid: challenge,
+                    challenge,
                     pubkey: self
                         .args
                         .comm_pubkey

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,6 +16,7 @@ derivative = "2.2.0"
 eyre = "0.6.11"
 frost-core = { version = "2.0.0", features = ["serde"] }
 frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
+hex = "0.4"
 rand = "0.8"
 rcgen = "0.13.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -32,7 +33,6 @@ xeddsa = "1.0.2"
 futures-util = "0.3.31"
 futures = "0.3.31"
 thiserror = "2.0.3"
-hex = "0.4.3"
 
 [dev-dependencies]
 axum-test = "16.4.0"

--- a/server/README.md
+++ b/server/README.md
@@ -1,14 +1,12 @@
 # FROST Server
 
-
-This is a HTTP server that allow clients (Coordinator and Participants) to
-run FROST without needing to directly connect to one another.
+This is a JSON-HTTPS server that allow FROST clients (Coordinator and
+Participants) to run FROST without needing to directly connect to one another.
 
 
 ## Status ⚠
 
-This is a prototype which is NOT SECURE since messages are not encrypted nor
-authenticated. DO NOT USE this for anything other than testing.
+This project has not being audited.
 
 
 ## Usage
@@ -17,19 +15,14 @@ NOTE: This is for demo purposes only and should not be used in production.
 
 You will need to have [Rust and Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) installed.
 
-To run:
+To compile and run:
+
 1. Clone the repo. Run `git clone https://github.com/ZcashFoundation/frost-zcash-demo.git`
-2. Run `cargo install`
-3. Run `cargo run --bin server`
+2. Run `cargo build --release --bin server`
+3. Run `./target/release/server -h` to learn about the command line arguments.
 
-You can specify the IP and port to bind to using `--ip` and `--port`, e.g.
-`cargo run --bin server -- --ip 127.0.0.1 --port 2744`.
+You will need to specify a TLS certificate and key with the `--tls-cert`
+and `--tls-key` arguments.
 
-## TODO
-
-- Add specific error codes
-- Remove frost-specific types (when data is encrypted)
-- Session timeouts
-- Encryption/authentication
-- DoS protections and other production-ready requirements
--
+For more details on using and deploying, refer to the [ZF FROST
+Book](https://frost.zfnd.org/).

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -49,9 +49,10 @@ pub async fn run(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
 
     if args.no_tls_very_insecure {
         tracing::warn!(
-            "starting an INSECURE HTTP server. This should be done only for \
-            testing or if you are providing TLS/HTTPS with a separate \
-            mechanism (e.g. reverse proxy such as nginx)"
+            "starting an INSECURE HTTP server at {}. This should be done only \
+            for testing or if you are providing TLS/HTTPS with a separate \
+            mechanism (e.g. reverse proxy such as nginx)",
+            addr,
         );
         let listener = tokio::net::TcpListener::bind(addr).await?;
         Ok(axum::serve(listener, app).await?)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,12 +1,20 @@
 use clap::Parser;
 use server::args::Args;
 use server::run;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     // initialize tracing
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
     tracing::event!(tracing::Level::INFO, "server running");
     run(&args).await
 }

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -42,8 +42,6 @@ pub struct Session {
     pub(crate) pubkeys: Vec<Vec<u8>>,
     /// The public key of the coordinator
     pub(crate) coordinator_pubkey: Vec<u8>,
-    /// The number of signers in the session.
-    pub(crate) num_signers: u16,
     /// The number of messages being simultaneously signed.
     pub(crate) message_count: u8,
     /// The message queue.

--- a/server/src/types.rs
+++ b/server/src/types.rs
@@ -32,7 +32,7 @@ pub struct ChallengeOutput {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct KeyLoginArgs {
-    pub uuid: Uuid,
+    pub challenge: Uuid,
     #[serde(
         serialize_with = "serdect::slice::serialize_hex_lower_or_bin",
         deserialize_with = "serdect::slice::deserialize_hex_or_bin_vec"
@@ -64,7 +64,6 @@ pub struct LoginArgs {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CreateNewSessionArgs {
     pub pubkeys: Vec<PublicKey>,
-    pub num_signers: u16,
     pub message_count: u8,
 }
 
@@ -85,7 +84,6 @@ pub struct GetSessionInfoArgs {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetSessionInfoOutput {
-    pub num_signers: u16,
     pub message_count: u8,
     pub pubkeys: Vec<PublicKey>,
     pub coordinator_pubkey: Vec<u8>,

--- a/server/tests/integration_tests.rs
+++ b/server/tests/integration_tests.rs
@@ -89,7 +89,7 @@ async fn test_main_router<
     let res = server
         .post("/login")
         .json(&server::KeyLoginArgs {
-            uuid: alice_challenge,
+            challenge: alice_challenge,
             pubkey: alice_keypair.public.clone(),
             signature: alice_signature.to_vec(),
         })
@@ -104,7 +104,7 @@ async fn test_main_router<
     let res = server
         .post("/login")
         .json(&server::KeyLoginArgs {
-            uuid: bob_challenge,
+            challenge: bob_challenge,
             pubkey: bob_keypair.public.clone(),
             signature: bob_signature.to_vec(),
         })
@@ -124,7 +124,6 @@ async fn test_main_router<
                 server::PublicKey(alice_keypair.public.clone()),
                 server::PublicKey(bob_keypair.public.clone()),
             ],
-            num_signers: 2,
             message_count: 2,
         })
         .await;
@@ -463,7 +462,7 @@ async fn test_http() -> Result<(), Box<dyn std::error::Error>> {
     let r = client
         .post("https://127.0.0.1:2744/login")
         .json(&server::KeyLoginArgs {
-            uuid: alice_challenge,
+            challenge: alice_challenge,
             pubkey: alice_keypair.public.clone(),
             signature: alice_signature.to_vec(),
         })
@@ -485,7 +484,6 @@ async fn test_http() -> Result<(), Box<dyn std::error::Error>> {
                 server::PublicKey(bob_keypair.public.clone()),
             ],
             message_count: 1,
-            num_signers: 2,
         })
         .send()
         .await?;
@@ -528,7 +526,7 @@ async fn test_http() -> Result<(), Box<dyn std::error::Error>> {
     let r = client
         .post("https://127.0.0.1:2744/login")
         .json(&server::KeyLoginArgs {
-            uuid: bob_challenge,
+            challenge: bob_challenge,
             pubkey: bob_keypair.public.clone(),
             signature: bob_signature.to_vec(),
         })


### PR DESCRIPTION
Based on #307 

This improves some stuff I noticed while working on https://github.com/ZcashFoundation/frost/pull/811

- Change default port of clients to 443 (this will mismatch with the server default 2744 on purpose; the user is supposed to deploy nginx on 443 and redirect to 2744, or do their own thing by specifying the ports using the flags)
- Use `PublicKey` for other instances of public key in arguments, to make sure they're serialized as hex strings and not as arrays of numbers
- Remove `num_signers` from session handling, it's not really needed
- Make the server logs in INFO level by default (before it wouldn't log anything unless RUST_LOG variable was set)
- Change tracing logs to DEBUG instead of INFO
- Renamed `uuid` argument to `challenge`
