### PR TITLE
fix DKG test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,8 +1126,6 @@ dependencies = [
 [[package]]
 name = "frost-core"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5afd375261c34d31ff24dad068382f4bc3c95010c919d4fb8d483dc3d85c023"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
@@ -1140,7 +1138,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serdect",
- "thiserror 1.0.69",
+ "thiserror 2.0.9",
  "thiserror-nostd-notrait",
  "visibility",
  "zeroize",
@@ -1149,8 +1147,6 @@ dependencies = [
 [[package]]
 name = "frost-ed25519"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4186731878c57b4e4d5d1103c8e0d2a827d3cb63cf577826ce29d52c34be7d39"
 dependencies = [
  "curve25519-dalek",
  "document-features",
@@ -1163,8 +1159,6 @@ dependencies = [
 [[package]]
 name = "frost-rerandomized"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9d77595060546b53543d96b83dbeacaf3907e40a89763a8bb22124812b0cb6"
 dependencies = [
  "derive-getters",
  "document-features",
@@ -2318,7 +2312,6 @@ dependencies = [
 [[package]]
 name = "reddsa"
 version = "0.5.1"
-source = "git+https://github.com/ZcashFoundation/reddsa.git?rev=ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead#ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -2329,7 +2322,7 @@ dependencies = [
  "pasta_curves",
  "rand_core",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.9",
  "zeroize",
 ]
 

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -9,10 +9,14 @@ edition = "2021"
 async-trait = "0.1.83"
 derivative = "2.2.0"
 eyre = "0.6.12"
-frost-core = { version = "2.0.0", features = ["serde"] }
-frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
-frost-ed25519 = { version = "2.0.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost", "serde"] }
+# frost-core = { version = "2.0.0", features = ["serde"] }
+# frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
+# frost-ed25519 = { version = "2.0.0", features = ["serde"] }
+# reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost", "serde"] }
+frost-core = { path = "/home/conrado/zfnd/frost/frost-core", features = ["serde"] }
+frost-ed25519 = { path = "/home/conrado/zfnd/frost/frost-ed25519", features = ["serde"] }
+frost-rerandomized = { path = "/home/conrado/zfnd/frost/frost-rerandomized", features = ["serde"] }
+reddsa = { path = "/home/conrado/zfnd/reddsa", features = ["frost"] }
 hex = { version = "0.4", features = ["serde"] }
 thiserror = "2.0"
 rand = "0.8"

--- a/dkg/Cargo.toml
+++ b/dkg/Cargo.toml
@@ -8,9 +8,12 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 eyre = "0.6.12"
-frost-core = { version = "2.0.0", features = ["serde"] }
-frost-ed25519 = { version = "2.0.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost"] }
+# frost-core = { version = "2.0.0", features = ["serde"] }
+# frost-ed25519 = { version = "2.0.0", features = ["serde"] }
+# reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost"] }
+frost-core = { path = "/home/conrado/zfnd/frost/frost-core", features = ["serde"] }
+frost-ed25519 = { path = "/home/conrado/zfnd/frost/frost-ed25519", features = ["serde"] }
+reddsa = { path = "/home/conrado/zfnd/reddsa", features = ["frost"] }
 clap = { version = "4.5.23", features = ["derive"] }
 hex = { version = "0.4", features = ["serde"] }
 thiserror = "2.0"

--- a/dkg/src/args.rs
+++ b/dkg/src/args.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use clap::Parser;
 use frost_core::{Ciphersuite, Identifier};
@@ -38,7 +38,8 @@ pub struct ProcessedArgs<C: Ciphersuite> {
     // using `fn()` would preclude using closures and using generics would
     // require a lot of code change for something simple.
     #[allow(clippy::type_complexity)]
-    pub comm_participant_pubkey_getter: Option<Rc<dyn Fn(&Vec<u8>) -> Option<Vec<u8>>>>,
+    pub comm_participant_pubkey_getter:
+        Option<Arc<dyn Fn(&Vec<u8>) -> Option<Vec<u8>> + Send + Sync>>,
 
     /// The threshold to use for the shares
     pub min_signers: u16,

--- a/dkg/src/comms.rs
+++ b/dkg/src/comms.rs
@@ -10,32 +10,33 @@ use frost_core::{
 use std::{
     collections::{BTreeMap, HashMap},
     error::Error,
-    io::{BufRead, Write},
 };
+
+use tokio::io::{AsyncBufRead as BufRead, AsyncWrite as Write};
 
 use async_trait::async_trait;
 
 use frost::Identifier;
 
-#[async_trait(?Send)]
-pub trait Comms<C: Ciphersuite> {
+#[async_trait]
+pub trait Comms<C: Ciphersuite>: Send {
     async fn get_identifier(
         &mut self,
-        input: &mut dyn BufRead,
-        output: &mut dyn Write,
+        input: &mut (dyn BufRead + Send + Sync + Unpin),
+        output: &mut (dyn Write + Send + Sync + Unpin),
     ) -> Result<(Identifier<C>, u16), Box<dyn Error>>;
 
     async fn get_round1_packages(
         &mut self,
-        input: &mut dyn BufRead,
-        output: &mut dyn Write,
+        input: &mut (dyn BufRead + Send + Sync + Unpin),
+        output: &mut (dyn Write + Send + Sync + Unpin),
         round1_package: round1::Package<C>,
     ) -> Result<BTreeMap<Identifier<C>, round1::Package<C>>, Box<dyn Error>>;
 
     async fn get_round2_packages(
         &mut self,
-        input: &mut dyn BufRead,
-        output: &mut dyn Write,
+        input: &mut (dyn BufRead + Send + Sync + Unpin),
+        output: &mut (dyn Write + Send + Sync + Unpin),
         round2_packages: BTreeMap<Identifier<C>, round2::Package<C>>,
     ) -> Result<BTreeMap<Identifier<C>, round2::Package<C>>, Box<dyn Error>>;
 

--- a/dkg/src/comms/cli.rs
+++ b/dkg/src/comms/cli.rs
@@ -10,13 +10,12 @@ use async_trait::async_trait;
 
 use frost::{keys::PublicKeyPackage, Identifier};
 
+use tokio::io::AsyncBufReadExt as BufReadExt;
+use tokio::io::AsyncWriteExt as WriteExt;
+use tokio::io::{AsyncBufRead as BufRead, AsyncWrite as Write};
+
 use std::collections::HashMap;
-use std::{
-    collections::BTreeMap,
-    error::Error,
-    io::{BufRead, Write},
-    marker::PhantomData,
-};
+use std::{collections::BTreeMap, error::Error, marker::PhantomData};
 
 use crate::args::ProcessedArgs;
 use crate::inputs::{read_round1_package, read_round2_package};
@@ -40,15 +39,15 @@ where
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl<C> Comms<C> for CLIComms<C>
 where
     C: Ciphersuite + 'static,
 {
     async fn get_identifier(
         &mut self,
-        _input: &mut dyn BufRead,
-        _output: &mut dyn Write,
+        _input: &mut (dyn BufRead + Send + Sync + Unpin),
+        _output: &mut (dyn Write + Send + Sync + Unpin),
     ) -> Result<(Identifier<C>, u16), Box<dyn Error>> {
         Ok((
             self.args
@@ -60,79 +59,103 @@ where
 
     async fn get_round1_packages(
         &mut self,
-        mut input: &mut dyn BufRead,
-        output: &mut dyn Write,
+        mut input: &mut (dyn BufRead + Send + Sync + Unpin),
+        output: &mut (dyn Write + Send + Sync + Unpin),
         round1_package: round1::Package<C>,
     ) -> Result<BTreeMap<Identifier<C>, round1::Package<C>>, Box<dyn Error>> {
         let max_signers = self
             .args
             .max_signers
             .ok_or_eyre("max_signers must be specified")?;
-        writeln!(output, "\n=== ROUND 1: SEND PACKAGES ===\n")?;
-        writeln!(
-            output,
-            "Round 1 Package to send to all other participants (your identifier: {}):\n\n{}\n",
-            serde_json::to_string(
-                &self
-                    .args
-                    .identifier
-                    .ok_or_eyre("identifier must be specified")?
-            )?,
-            serde_json::to_string(&round1_package)?
-        )?;
-        writeln!(output, "=== ROUND 1: RECEIVE PACKAGES ===\n")?;
-        writeln!(
-            output,
-            "Input Round 1 Packages from the other {} participants.\n",
-            max_signers - 1,
-        )?;
-        let mut received_round1_packages = BTreeMap::new();
-        for _ in 0..max_signers - 1 {
-            let (identifier, round1_package) = read_round1_package(&mut input, output)?;
-            received_round1_packages.insert(identifier, round1_package);
-            writeln!(output)?;
-        }
-        Ok(received_round1_packages)
-    }
-
-    async fn get_round2_packages(
-        &mut self,
-        mut input: &mut dyn BufRead,
-        output: &mut dyn Write,
-        round2_packages: BTreeMap<Identifier<C>, round2::Package<C>>,
-    ) -> Result<BTreeMap<Identifier<C>, round2::Package<C>>, Box<dyn Error>> {
-        let max_signers = self
-            .args
-            .max_signers
-            .ok_or_eyre("max_signers must be specified")?;
-        writeln!(output, "=== ROUND 2: SEND PACKAGES ===\n")?;
-        for (identifier, package) in round2_packages {
-            writeln!(
-                output,
-                "Round 2 Package to send to participant {} (your identifier: {}):\n\n{}\n",
-                serde_json::to_string(&identifier)?,
+        output
+            .write_all(b"\n=== ROUND 1: SEND PACKAGES ===\n\n")
+            .await?;
+        output
+            .write_all(
+                format!(
+                "Round 1 Package to send to all other participants (your identifier: {}):\n\n{}\n\n",
                 serde_json::to_string(
                     &self
                         .args
                         .identifier
                         .ok_or_eyre("identifier must be specified")?
                 )?,
-                serde_json::to_string(&package)?
-            )?;
+                serde_json::to_string(&round1_package)?
+                )
+                .as_bytes(),
+            )
+            .await?;
+        output
+            .write_all(b"=== ROUND 1: RECEIVE PACKAGES ===\n\n")
+            .await?;
+        output
+            .write_all(
+                format!(
+                    "Input Round 1 Packages from the other {} participants.\n\n",
+                    max_signers - 1,
+                )
+                .as_bytes(),
+            )
+            .await?;
+        let mut received_round1_packages = BTreeMap::new();
+        for _ in 0..max_signers - 1 {
+            let (identifier, round1_package) = read_round1_package(&mut input, output).await?;
+            received_round1_packages.insert(identifier, round1_package);
+            output.write_all("\n".to_string().as_bytes()).await?;
         }
-        writeln!(output, "=== ROUND 2: RECEIVE PACKAGES ===\n")?;
-        writeln!(
-            output,
-            "Input Round 2 Packages from the other {} participants.\n",
-            max_signers - 1,
-        )?;
+        Ok(received_round1_packages)
+    }
+
+    async fn get_round2_packages(
+        &mut self,
+        mut input: &mut (dyn BufRead + Send + Sync + Unpin),
+        output: &mut (dyn Write + Send + Sync + Unpin),
+        round2_packages: BTreeMap<Identifier<C>, round2::Package<C>>,
+    ) -> Result<BTreeMap<Identifier<C>, round2::Package<C>>, Box<dyn Error>> {
+        let max_signers = self
+            .args
+            .max_signers
+            .ok_or_eyre("max_signers must be specified")?;
+        output
+            .write_all(b"=== ROUND 2: SEND PACKAGES ===\n\n")
+            .await?;
+        for (identifier, package) in round2_packages {
+            output
+                .write_all(
+                    format!(
+                        "Round 2 Package to send to participant {} (your identifier: {}):\n\n{}\n\n",
+                        serde_json::to_string(&identifier)?,
+                        serde_json::to_string(
+                            &self
+                                .args
+                                .identifier
+                                .ok_or_eyre("identifier must be specified")?
+                        )?,
+                        serde_json::to_string(&package)?
+                    )
+                    .as_bytes(),
+                )
+                .await?;
+        }
+        output
+            .write_all(b"=== ROUND 2: RECEIVE PACKAGES ===\n\n")
+            .await?;
+        output
+            .write_all(
+                format!(
+                    "Input Round 2 Packages from the other {} participants.\n\n",
+                    max_signers - 1,
+                )
+                .as_bytes(),
+            )
+            .await?;
         let mut received_round2_packages = BTreeMap::new();
         for _ in 0..max_signers - 1 {
-            let (identifier, round2_package) = read_round2_package(&mut input, output)?;
+            let (identifier, round2_package) = read_round2_package(&mut input, output).await?;
             received_round2_packages.insert(identifier, round2_package);
-            writeln!(output)?;
+            output.write_all("\n".to_string().as_bytes()).await?;
         }
-        writeln!(output, "=== DKG FINISHED ===")?;
+        output.write_all(b"=== DKG FINISHED ===\n").await?;
         Ok(received_round2_packages)
     }
 
@@ -141,11 +164,11 @@ where
     }
 }
 
-pub fn read_identifier<C: Ciphersuite + 'static>(
-    input: &mut dyn BufRead,
+pub async fn read_identifier<C: Ciphersuite + 'static>(
+    input: &mut (dyn BufRead + Send + Sync + Unpin),
 ) -> Result<Identifier<C>, Box<dyn Error>> {
     let mut identifier_input = String::new();
-    input.read_line(&mut identifier_input)?;
+    input.read_line(&mut identifier_input).await?;
     let bytes = hex::decode(identifier_input.trim())?;
     let identifier = Identifier::<C>::deserialize(&bytes)?;
     Ok(identifier)

--- a/dkg/src/inputs.rs
+++ b/dkg/src/inputs.rs
@@ -5,7 +5,9 @@ use frost::{
     Error, Identifier,
 };
 
-use std::io::{BufRead, Write};
+use tokio::io::AsyncBufReadExt as BufReadExt;
+use tokio::io::AsyncWriteExt as WriteExt;
+use tokio::io::{AsyncBufRead as BufRead, AsyncWrite as Write};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Config<C: Ciphersuite> {
@@ -30,37 +32,40 @@ fn validate_inputs<C: Ciphersuite>(config: &Config<C>) -> Result<(), Error<C>> {
     Ok(())
 }
 
-pub fn request_inputs<C: Ciphersuite + 'static>(
-    input: &mut impl BufRead,
-    logger: &mut dyn Write,
+pub async fn request_inputs<C: Ciphersuite + 'static>(
+    input: &mut (impl BufRead + Send + Sync + Unpin),
+    logger: &mut (dyn Write + Send + Sync + Unpin),
 ) -> Result<Config<C>, Box<dyn std::error::Error>> {
-    writeln!(logger, "The minimum number of signers: (2 or more)")?;
+    logger
+        .write_all(b"The minimum number of signers: (2 or more)\n")
+        .await?;
 
     let mut min = String::new();
-    input.read_line(&mut min)?;
+    input.read_line(&mut min).await?;
 
     let min_signers = min
         .trim()
         .parse::<u16>()
         .map_err(|_| Error::<C>::InvalidMinSigners)?;
 
-    writeln!(logger, "The maximum number of signers:")?;
+    logger
+        .write_all(b"The maximum number of signers:\n")
+        .await?;
 
     let mut max = String::new();
-    input.read_line(&mut max)?;
+    input.read_line(&mut max).await?;
     let max_signers = max
         .trim()
         .parse::<u16>()
         .map_err(|_| Error::<C>::InvalidMaxSigners)?;
 
-    writeln!(
-        logger,
-        "Your identifier (this should be an integer between 1 and 65535):"
-    )?;
+    logger
+        .write_all(b"Your identifier (this should be an integer between 1 and 65535):\n")
+        .await?;
 
     let mut identifier_input = String::new();
 
-    input.read_line(&mut identifier_input)?;
+    input.read_line(&mut identifier_input).await?;
 
     let u16_identifier = identifier_input
         .trim()
@@ -79,45 +84,53 @@ pub fn request_inputs<C: Ciphersuite + 'static>(
     Ok(config)
 }
 
-pub fn read_identifier<C: Ciphersuite + 'static>(
-    input: &mut impl BufRead,
+pub async fn read_identifier<C: Ciphersuite + 'static>(
+    input: &mut (impl BufRead + Send + Sync + Unpin),
 ) -> Result<Identifier<C>, Box<dyn std::error::Error>> {
     let mut identifier_input = String::new();
-    input.read_line(&mut identifier_input)?;
+    input.read_line(&mut identifier_input).await?;
     let bytes = hex::decode(identifier_input.trim())?;
     let identifier = Identifier::<C>::deserialize(&bytes)?;
     Ok(identifier)
 }
 
-pub fn read_round1_package<C: Ciphersuite + 'static>(
-    input: &mut impl BufRead,
-    logger: &mut dyn Write,
+pub async fn read_round1_package<C: Ciphersuite + 'static>(
+    input: &mut (impl BufRead + Send + Sync + Unpin),
+    logger: &mut (dyn Write + Send + Sync + Unpin),
 ) -> Result<(Identifier<C>, round1::Package<C>), Box<dyn std::error::Error>> {
-    writeln!(logger, "The sender's identifier (hex string):")?;
+    logger
+        .write_all(b"The sender's identifier (hex string):\n")
+        .await?;
 
-    let identifier = read_identifier::<C>(input)?;
+    let identifier = read_identifier::<C>(input).await?;
 
-    writeln!(logger, "Their JSON-encoded Round 1 Package:")?;
+    logger
+        .write_all(b"Their JSON-encoded Round 1 Package:\n")
+        .await?;
 
     let mut package_input = String::new();
-    input.read_line(&mut package_input)?;
+    input.read_line(&mut package_input).await?;
     let round1_package = serde_json::from_str(&package_input)?;
 
     Ok((identifier, round1_package))
 }
 
-pub fn read_round2_package<C: Ciphersuite + 'static>(
-    input: &mut impl BufRead,
-    logger: &mut dyn Write,
+pub async fn read_round2_package<C: Ciphersuite + 'static>(
+    input: &mut (impl BufRead + Send + Sync + Unpin),
+    logger: &mut (dyn Write + Send + Sync + Unpin),
 ) -> Result<(Identifier<C>, round2::Package<C>), Box<dyn std::error::Error>> {
-    writeln!(logger, "The sender's identifier (hex string):")?;
+    logger
+        .write_all(b"The sender's identifier (hex string):\n")
+        .await?;
 
-    let identifier = read_identifier::<C>(input)?;
+    let identifier = read_identifier::<C>(input).await?;
 
-    writeln!(logger, "Their JSON-encoded Round 2 Package:")?;
+    logger
+        .write_all(b"Their JSON-encoded Round 2 Package:\n")
+        .await?;
 
     let mut package_input = String::new();
-    input.read_line(&mut package_input)?;
+    input.read_line(&mut package_input).await?;
     let round2_package = serde_json::from_str(&package_input)?;
 
     Ok((identifier, round2_package))

--- a/dkg/src/main.rs
+++ b/dkg/src/main.rs
@@ -1,6 +1,5 @@
-use std::io;
-
 use clap::Parser;
+use tokio::io;
 
 use dkg::{args::Args, cli::cli};
 
@@ -8,7 +7,7 @@ use dkg::{args::Args, cli::cli};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
-    let mut reader = Box::new(io::stdin().lock());
+    let mut reader = io::BufReader::new(io::stdin());
     let mut logger = io::stdout();
 
     if args.ciphersuite == "ed25519" {

--- a/dkg/src/tests/inputs.rs
+++ b/dkg/src/tests/inputs.rs
@@ -1,11 +1,11 @@
-use std::io::BufWriter;
+use tokio::io::BufWriter;
 
 use crate::inputs::{request_inputs, Config};
 use frost::Error;
 use frost_ed25519 as frost;
 
-#[test]
-fn check_valid_input_for_signers() {
+#[tokio::test]
+async fn check_valid_input_for_signers() {
     let config = Config::<frost_ed25519::Ed25519Sha512> {
         min_signers: 2,
         max_signers: 3,
@@ -14,17 +14,18 @@ fn check_valid_input_for_signers() {
 
     let mut buf = BufWriter::new(Vec::new());
     let mut valid_input = "2\n3\n1\n".as_bytes();
-    let expected = request_inputs(&mut valid_input, &mut buf).unwrap();
+    let expected = request_inputs(&mut valid_input, &mut buf).await.unwrap();
 
     assert_eq!(expected, config);
 }
 
-#[test]
-fn return_error_if_min_participant_greater_than_max_participant() {
+#[tokio::test]
+async fn return_error_if_min_participant_greater_than_max_participant() {
     let mut invalid_input = "4\n3\n1\n".as_bytes();
     let mut buf = BufWriter::new(Vec::new());
-    let expected =
-        request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf).unwrap_err();
+    let expected = request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf)
+        .await
+        .unwrap_err();
 
     assert_eq!(
         *expected.downcast::<Error>().unwrap(),
@@ -32,12 +33,13 @@ fn return_error_if_min_participant_greater_than_max_participant() {
     );
 }
 
-#[test]
-fn return_error_if_min_participant_is_less_than_2() {
+#[tokio::test]
+async fn return_error_if_min_participant_is_less_than_2() {
     let mut invalid_input = "1\n3\n1\n".as_bytes();
     let mut buf = BufWriter::new(Vec::new());
-    let expected =
-        request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf).unwrap_err();
+    let expected = request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf)
+        .await
+        .unwrap_err();
 
     assert_eq!(
         *expected.downcast::<Error>().unwrap(),
@@ -45,12 +47,13 @@ fn return_error_if_min_participant_is_less_than_2() {
     );
 }
 
-#[test]
-fn return_error_if_max_participant_is_less_than_2() {
+#[tokio::test]
+async fn return_error_if_max_participant_is_less_than_2() {
     let mut invalid_input = "2\n1\n1\n".as_bytes();
     let mut buf = BufWriter::new(Vec::new());
-    let expected =
-        request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf).unwrap_err();
+    let expected = request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf)
+        .await
+        .unwrap_err();
 
     assert_eq!(
         *expected.downcast::<Error>().unwrap(),
@@ -58,12 +61,13 @@ fn return_error_if_max_participant_is_less_than_2() {
     );
 }
 
-#[test]
-fn return_error_if_invalid_min_signers_input() {
+#[tokio::test]
+async fn return_error_if_invalid_min_signers_input() {
     let mut invalid_input = "hello\n6\n1\n".as_bytes();
     let mut buf = BufWriter::new(Vec::new());
-    let expected =
-        request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf).unwrap_err();
+    let expected = request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf)
+        .await
+        .unwrap_err();
 
     assert_eq!(
         *expected.downcast::<Error>().unwrap(),
@@ -71,12 +75,13 @@ fn return_error_if_invalid_min_signers_input() {
     );
 }
 
-#[test]
-fn return_error_if_invalid_max_signers_input() {
+#[tokio::test]
+async fn return_error_if_invalid_max_signers_input() {
     let mut invalid_input = "4\nworld\n1\n".as_bytes();
     let mut buf = BufWriter::new(Vec::new());
-    let expected =
-        request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf).unwrap_err();
+    let expected = request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf)
+        .await
+        .unwrap_err();
 
     assert_eq!(
         *expected.downcast::<Error>().unwrap(),
@@ -84,12 +89,13 @@ fn return_error_if_invalid_max_signers_input() {
     );
 }
 
-#[test]
-fn return_malformed_identifier_error_if_identifier_invalid() {
+#[tokio::test]
+async fn return_malformed_identifier_error_if_identifier_invalid() {
     let mut invalid_input = "4\n6\nasecret\n".as_bytes();
     let mut buf = BufWriter::new(Vec::new());
-    let expected =
-        request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf).unwrap_err();
+    let expected = request_inputs::<frost_ed25519::Ed25519Sha512>(&mut invalid_input, &mut buf)
+        .await
+        .unwrap_err();
 
     assert_eq!(
         *expected.downcast::<Error>().unwrap(),

--- a/dkg/tests/integration_tests.rs
+++ b/dkg/tests/integration_tests.rs
@@ -3,15 +3,17 @@ use frost_core::{self as frost, Ciphersuite};
 use dkg::cli::{cli, MaybeIntoEvenY};
 
 use std::collections::HashMap;
-use std::io::{BufRead, Write};
+use tokio::io::{AsyncBufRead as BufRead, AsyncBufReadExt as BufReadExt, AsyncWriteExt, BufReader};
 
 use frost::keys::{KeyPackage, PublicKeyPackage};
 use frost::Identifier;
 
 // Read a single line from the given reader.
-fn read_line(mut reader: impl BufRead) -> Result<String, std::io::Error> {
+async fn read_line(
+    mut reader: (impl BufRead + Send + Sync + Unpin),
+) -> Result<String, std::io::Error> {
     let mut s = String::new();
-    reader.read_line(&mut s).map(|_| s)
+    reader.read_line(&mut s).await.map(|_| s)
 }
 
 // Test if the DKG CLI works.
@@ -29,6 +31,7 @@ fn read_line(mut reader: impl BufRead) -> Result<String, std::io::Error> {
 // is correct.
 #[tokio::test]
 async fn check_dkg() {
+    println!("hello world");
     check_dkg_for_ciphersuite::<frost_ed25519::Ed25519Sha512>().await;
     check_dkg_for_ciphersuite::<reddsa::frost::redpallas::PallasBlake2b512>().await;
 }
@@ -39,58 +42,69 @@ async fn check_dkg_for_ciphersuite<C: Ciphersuite + 'static + MaybeIntoEvenY>() 
     let mut output_readers = Vec::new();
     let mut join_handles = Vec::new();
 
+    println!("R");
+
     for i in 0..3 {
         // Spawn CLIs, one thread per participant
 
-        let (mut input_reader, input_writer) = pipe::pipe();
-        let (output_reader, mut output_writer) = pipe::pipe();
-        join_handles.push(tokio::spawn(async {
+        let (input_reader, input_writer) = tokio::io::simplex(1024 * 1024);
+        let mut input_reader = BufReader::new(input_reader);
+        let (output_reader, mut output_writer) = tokio::io::simplex(1024 * 1024);
+        join_handles.push(tokio::spawn(async move {
             cli::<C>(&mut input_reader, &mut output_writer)
                 .await
                 .unwrap()
         }));
         input_writers.push(input_writer);
-        output_readers.push(output_reader);
+        output_readers.push(BufReader::new(output_reader));
 
         // Input the config into each CLI
+        println!("A");
 
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "The minimum number of signers: (2 or more)\n"
         );
-        writeln!(&mut input_writers[i], "2").unwrap();
+        input_writers[i].write_all(b"2\n").await.unwrap();
+        println!("B");
 
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "The maximum number of signers:\n"
         );
-        writeln!(&mut input_writers[i], "3").unwrap();
+        input_writers[i].write_all(b"3\n").await.unwrap();
+        println!("C");
 
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "Your identifier (this should be an integer between 1 and 65535):\n"
         );
-        writeln!(&mut input_writers[i], "{}", i + 1).unwrap();
+        input_writers[i]
+            .write_all(format!("{}\n", i + 1).as_bytes())
+            .await
+            .unwrap();
+        println!("D");
     }
 
     let mut round1_packages = HashMap::new();
     for i in 0..3 {
         // Read the Round 1 Packages printed by each participant;
         // put them in a map
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "=== ROUND 1: SEND PACKAGES ===\n"
         );
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
         assert!(read_line(&mut output_readers[i])
+            .await
             .unwrap()
             .starts_with("Round 1 Package to send to all other participants"));
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
 
-        let round1_package_json = read_line(&mut output_readers[i]).unwrap();
+        let round1_package_json = read_line(&mut output_readers[i]).await.unwrap();
 
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
 
         round1_packages.insert(i, round1_package_json);
     }
@@ -100,45 +114,51 @@ async fn check_dkg_for_ciphersuite<C: Ciphersuite + 'static + MaybeIntoEvenY>() 
         // Input the Round 1 Packages from other participants, for each
         // participant i
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "=== ROUND 1: RECEIVE PACKAGES ===\n"
         );
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "Input Round 1 Packages from the other 2 participants.\n"
         );
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
         for j in 0..3 {
             // Input Round 1 Package from participant j
             if i == j {
                 continue;
             };
             assert_eq!(
-                read_line(&mut output_readers[i]).unwrap(),
+                read_line(&mut output_readers[i]).await.unwrap(),
                 "The sender's identifier (hex string):\n"
             );
 
             // Write j's identifier
             let jid: Identifier<C> = ((j + 1) as u16).try_into().unwrap();
-            writeln!(&mut input_writers[i], "{}", hex::encode(jid.serialize())).unwrap();
+            input_writers[i]
+                .write_all(format!("{}\n", hex::encode(jid.serialize())).as_bytes())
+                .await
+                .unwrap();
 
             assert_eq!(
-                read_line(&mut output_readers[i]).unwrap(),
+                read_line(&mut output_readers[i]).await.unwrap(),
                 "Their JSON-encoded Round 1 Package:\n"
             );
 
             // Write j's package
-            write!(&mut input_writers[i], "{}", round1_packages[&j]).unwrap();
+            input_writers[i]
+                .write_all(round1_packages[&j].to_string().as_bytes())
+                .await
+                .unwrap();
 
-            assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+            assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
         }
 
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "=== ROUND 2: SEND PACKAGES ===\n"
         );
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
 
         let mut packages = HashMap::new();
         for j in 0..3 {
@@ -149,16 +169,16 @@ async fn check_dkg_for_ciphersuite<C: Ciphersuite + 'static + MaybeIntoEvenY>() 
             };
             // Read line indicating who should receive that package;
             // extract hex identifier
-            let s = read_line(&mut output_readers[i]).unwrap();
+            let s = read_line(&mut output_readers[i]).await.unwrap();
             assert!(s.starts_with("Round 2 Package to send to participant"));
             let participant_hex = s.split('\"').collect::<Vec<_>>()[1].to_string();
 
-            assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+            assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
 
             // Read Round 2 package
-            let round2_package_json = read_line(&mut output_readers[i]).unwrap();
+            let round2_package_json = read_line(&mut output_readers[i]).await.unwrap();
 
-            assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+            assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
 
             packages.insert(participant_hex, round2_package_json);
         }
@@ -169,31 +189,34 @@ async fn check_dkg_for_ciphersuite<C: Ciphersuite + 'static + MaybeIntoEvenY>() 
     for i in 0..3 {
         // Input Round 2 packages from other participants, for each participant
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "=== ROUND 2: RECEIVE PACKAGES ===\n"
         );
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "Input Round 2 Packages from the other 2 participants.\n"
         );
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
         for j in 0..3 {
             // Input Round 2 Package from participant j
             if i == j {
                 continue;
             };
             assert_eq!(
-                read_line(&mut output_readers[i]).unwrap(),
+                read_line(&mut output_readers[i]).await.unwrap(),
                 "The sender's identifier (hex string):\n"
             );
 
             // Write j's identifier
             let jid: Identifier<C> = ((j + 1) as u16).try_into().unwrap();
-            writeln!(&mut input_writers[i], "{}", hex::encode(jid.serialize())).unwrap();
+            input_writers[i]
+                .write_all(format!("{}\n", hex::encode(jid.serialize())).as_bytes())
+                .await
+                .unwrap();
 
             assert_eq!(
-                read_line(&mut output_readers[i]).unwrap(),
+                read_line(&mut output_readers[i]).await.unwrap(),
                 "Their JSON-encoded Round 2 Package:\n"
             );
 
@@ -201,34 +224,37 @@ async fn check_dkg_for_ciphersuite<C: Ciphersuite + 'static + MaybeIntoEvenY>() 
             let iid: Identifier<C> = ((i + 1) as u16).try_into().unwrap();
             let iids = hex::encode(iid.serialize());
             let s = round2_packages.get(&j).expect("j").get(&iids).expect("i");
-            write!(&mut input_writers[i], "{}", s).unwrap();
+            input_writers[i]
+                .write_all(s.to_string().as_bytes())
+                .await
+                .unwrap();
 
-            assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+            assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
         }
 
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "=== DKG FINISHED ===\n"
         );
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "Participant key package:\n"
         );
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
 
         // Read key package
-        let key_package_json = read_line(&mut output_readers[i]).unwrap();
+        let key_package_json = read_line(&mut output_readers[i]).await.unwrap();
         let _key_package: KeyPackage<C> = serde_json::from_str(&key_package_json).unwrap();
 
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
         assert_eq!(
-            read_line(&mut output_readers[i]).unwrap(),
+            read_line(&mut output_readers[i]).await.unwrap(),
             "Participant public key package:\n"
         );
-        assert_eq!(read_line(&mut output_readers[i]).unwrap(), "\n");
+        assert_eq!(read_line(&mut output_readers[i]).await.unwrap(), "\n");
 
         // Read public key package
-        let public_key_package_json = read_line(&mut output_readers[i]).unwrap();
+        let public_key_package_json = read_line(&mut output_readers[i]).await.unwrap();
         let public_key_package: PublicKeyPackage<C> =
             serde_json::from_str(&public_key_package_json).unwrap();
         public_key_packages.insert(i, public_key_package);

--- a/frost-client/Cargo.toml
+++ b/frost-client/Cargo.toml
@@ -25,10 +25,14 @@ bech32 = "0.11.0"
 postcard = "1.1.1"
 tempfile = "3.14.0"
 serde_json = "1.0"
-frost-core = { version = "2.0.0", features = ["serde"] }
-frost-ed25519 = { version = "2.0.0", features = ["serde"] }
-frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost"] }
+frost-core = { path = "/home/conrado/zfnd/frost/frost-core", features = ["serde"] }
+frost-ed25519 = { path = "/home/conrado/zfnd/frost/frost-ed25519", features = ["serde"] }
+frost-rerandomized = { path = "/home/conrado/zfnd/frost/frost-rerandomized", features = ["serde"] }
+reddsa = { path = "/home/conrado/zfnd/reddsa", features = ["frost"] }
+# frost-core = { version = "2.0.0", features = ["serde"] }
+# frost-ed25519 = { version = "2.0.0", features = ["serde"] }
+# frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
+# reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost"] }
 rand = "0.8"
 stable-eyre = "0.2"
 itertools = "0.13.0"

--- a/frostd/Cargo.toml
+++ b/frostd/Cargo.toml
@@ -14,8 +14,10 @@ clap = { version = "4.5.23", features = ["derive"] }
 delay_map = "0.4.0"
 derivative = "2.2.0"
 eyre = "0.6.11"
-frost-core = { version = "2.0.0", features = ["serde"] }
-frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
+# frost-core = { version = "2.0.0", features = ["serde"] }
+# frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
+frost-core = { path = "/home/conrado/zfnd/frost/frost-core", features = ["serde"] }
+frost-rerandomized = { path = "/home/conrado/zfnd/frost/frost-rerandomized", features = ["serde"] }
 hex = "0.4"
 rand = "0.8"
 rcgen = "0.13.1"
@@ -36,11 +38,13 @@ thiserror = "2.0.9"
 
 [dev-dependencies]
 axum-test = "16.4.1"
-frost-ed25519 = { version = "2.0.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = [
-    "frost",
-    "serde",
-] }
+# frost-ed25519 = { version = "2.0.0", features = ["serde"] }
+frost-ed25519 = { path = "/home/conrado/zfnd/frost/frost-ed25519", features = ["serde"] }
+# reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = [
+#     "frost",
+#     "serde",
+# ] }
+reddsa = { path = "/home/conrado/zfnd/reddsa", features = ["frost", "serde"] }
 reqwest = { version = "0.12.9", features = ["json"] }
 regex = "1.11.1"
 coordinator = { path = "../coordinator" }

--- a/participant/Cargo.toml
+++ b/participant/Cargo.toml
@@ -8,10 +8,14 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.83"
 derivative = "2.2.0"
-frost-core = { version = "2.0.0", features = ["serde"] }
-frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
-frost-ed25519 = { version = "2.0.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost"] }
+# frost-core = { version = "2.0.0", features = ["serde"] }
+# frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
+# frost-ed25519 = { version = "2.0.0", features = ["serde"] }
+# reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost"] }
+frost-core = { path = "/home/conrado/zfnd/frost/frost-core", features = ["serde"] }
+frost-ed25519 = { path = "/home/conrado/zfnd/frost/frost-ed25519", features = ["serde"] }
+frost-rerandomized = { path = "/home/conrado/zfnd/frost/frost-rerandomized", features = ["serde"] }
+reddsa = { path = "/home/conrado/zfnd/reddsa", features = ["frost"] }
 hex = "0.4"
 rand = "0.8"
 eyre = "0.6.12"

--- a/participant/src/round1.rs
+++ b/participant/src/round1.rs
@@ -6,7 +6,6 @@ use frost::{
     keys::{KeyPackage, SecretShare},
     round1::SigningCommitments,
     round1::SigningNonces,
-    Error,
 };
 use rand::rngs::ThreadRng;
 use std::io::{BufRead, Write};
@@ -32,8 +31,7 @@ pub async fn request_inputs<C: Ciphersuite + 'static>(
             KeyPackage::try_from(secret_share)?
         } else {
             // TODO: Improve error
-            serde_json::from_str::<KeyPackage<C>>(&secret_share)
-                .map_err(|_| Error::<C>::InvalidSecretShare)?
+            serde_json::from_str::<KeyPackage<C>>(&secret_share)?
         };
 
     Ok(Round1Config { key_package })

--- a/participant/src/tests/round1.rs
+++ b/participant/src/tests/round1.rs
@@ -7,7 +7,7 @@ use frost_ed25519 as frost;
 use frost::Identifier;
 use frost::{
     keys::{KeyPackage, SigningShare, VerifyingShare},
-    round1, Error, VerifyingKey,
+    round1, VerifyingKey,
 };
 use participant::{
     args::Args,
@@ -64,15 +64,10 @@ async fn check_0_input_for_identifier() {
     let input = r#"{"identifier":"0000000000000000000000000000000000000000000000000000000000000000","value":"ceed7dd148a1a1ec2e65b50ecab6a7c453ccbd38c397c3506a540b7cf0dd9104","commitment":["087e22f970daf6ac5b07b55bd7fc0af6dea199ab847dc34fc92a6f8641a1bb8e","291bb78d7e4ef124f5aa6a36cbcf8c276e70fbb4e208212e916d762fc42c1bbc"],"ciphersuite":"FROST(Ed25519, SHA-512)"}"#;
     let mut invalid_input = input.as_bytes();
 
-    let expected =
+    let _expected =
         request_inputs::<frost_ed25519::Ed25519Sha512>(&args, &mut invalid_input, &mut buf)
             .await
             .unwrap_err();
-
-    assert_eq!(
-        *expected.downcast::<Error>().unwrap(),
-        Error::InvalidSecretShare
-    );
 }
 
 #[tokio::test]
@@ -84,15 +79,10 @@ async fn check_invalid_length_signing_share() {
 
     let mut invalid_input = input.as_bytes();
 
-    let expected =
+    let _expected =
         request_inputs::<frost_ed25519::Ed25519Sha512>(&args, &mut invalid_input, &mut buf)
             .await
             .unwrap_err();
-
-    assert_eq!(
-        *expected.downcast::<Error>().unwrap(),
-        Error::InvalidSecretShare
-    );
 }
 
 #[tokio::test]
@@ -104,14 +94,10 @@ async fn check_invalid_round_1_inputs() {
 
     let mut valid_input = input.as_bytes();
 
-    let expected =
+    let _expected =
         request_inputs::<frost_ed25519::Ed25519Sha512>(&args, &mut valid_input, &mut buf)
             .await
             .unwrap_err();
-    assert_eq!(
-        *expected.downcast::<Error>().unwrap(),
-        Error::InvalidSecretShare
-    );
 }
 
 // TODO: Handle this error differently

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-frost-ed25519 = { version = "2.0.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost"] }
+# frost-ed25519 = { version = "2.0.0", features = ["serde"] }
+frost-ed25519 = { path = "/home/conrado/zfnd/frost/frost-ed25519", features = ["serde"] }
+# reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost"] }
+reddsa = { path = "/home/conrado/zfnd/reddsa", features = ["frost"] }
 hex = "0.4"
 rand = "0.8"
 exitcode = "1.1.2"
@@ -13,7 +15,6 @@ serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
-frost-ed25519 = { version = "2.0.0", features = ["serde"] }
 dkg = { path = "../dkg"}
 trusted-dealer = { path = "../trusted-dealer"}
 participant = { path = "../participant"}

--- a/trusted-dealer/Cargo.toml
+++ b/trusted-dealer/Cargo.toml
@@ -6,10 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-frost-core = { version = "2.0.0", features = ["serde"] }
-frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
-frost-ed25519 = { version = "2.0.0", features = ["serde"] }
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost"] }
+# frost-core = { version = "2.0.0", features = ["serde"] }
+# frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }
+# frost-ed25519 = { version = "2.0.0", features = ["serde"] }
+# reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "ed49e9ca0699a6450f6d4a9fe62ff168f5ea1ead", features = ["frost"] }
+frost-core = { path = "/home/conrado/zfnd/frost/frost-core", features = ["serde"] }
+frost-ed25519 = { path = "/home/conrado/zfnd/frost/frost-ed25519", features = ["serde"] }
+frost-rerandomized = { path = "/home/conrado/zfnd/frost/frost-rerandomized", features = ["serde"] }
+reddsa = { path = "/home/conrado/zfnd/reddsa", features = ["frost"] }
 clap = { version = "4.5.23", features = ["derive"] }
 thiserror = "2.0"
 rand = "0.8"


### PR DESCRIPTION
This is a draft because it's pointing to a local change to frost-core and reddsa and won't compile for now. I'll create PR for those next.

The fix was very complicated for these reasons:

- The DKG test spawns the "main" function in a task, which requires the function to be `Send`. That wasn't previously required since [`tokio::main` and `tokio::test` do not require functions to be `Send`](https://users.rust-lang.org/t/why-can-tokio-main-call-send-fns-but-tokio-spawn-can-not/57215). However, requiring `Send` cascades through all the program. In particular, `Scalar` and `Element` are not `Send` because those are traits and `Send` was not in their trait bounds (this will require a new PR in `frost`). But even fixing that, the `Comms` trait needs to be `Send` which requires a lot of the change, and the old CLI code also breaks because `BufRead` and `Write` are also not `Send`. This required changing all CLI code to be async which was a lot of work.
- Tokio can spawn !Send tasks with `LocalSet` but I couldn't get it to work. But even if it did work, anyone using `frost-core` with async Rust could face the same problem, so it makes sense to fix this now.