### PR TITLE
coordinator, participant: don't send identifier; get it from channel authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "clap",
- "derivative",
  "exitcode",
  "eyre",
  "frost-core",

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.83"
-derivative = "2.2.0"
 eyre = "0.6.12"
 frost-core = { version = "2.0.0", features = ["serde"] }
 frost-rerandomized = { version = "2.0.0-rc.0", features = ["serde"] }

--- a/frost-client/src/config.rs
+++ b/frost-client/src/config.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use eyre::{eyre, OptionExt};
+use frost_core::{Ciphersuite, Identifier};
 use serde::{Deserialize, Serialize};
 
 use crate::{ciphersuite_helper::ciphersuite_helper, contact::Contact, write_atomic};
@@ -102,6 +103,16 @@ impl Group {
         }
         Ok(s)
     }
+
+    /// Get a group participant by their pubkey.
+    pub fn participant_by_pubkey(&self, pubkey: &[u8]) -> Result<Participant, Box<dyn Error>> {
+        Ok(self
+            .participant
+            .values()
+            .find(|p| p.pubkey == pubkey)
+            .cloned()
+            .ok_or_eyre("Participant not found")?)
+    }
 }
 
 /// A FROST group participant.
@@ -119,6 +130,13 @@ pub struct Participant {
         deserialize_with = "serdect::slice::deserialize_hex_or_bin_vec"
     )]
     pub pubkey: Vec<u8>,
+}
+
+impl Participant {
+    /// Return the parsed identifier for the participant.
+    pub fn identifier<C: Ciphersuite>(&self) -> Result<Identifier<C>, Box<dyn std::error::Error>> {
+        Ok(Identifier::<C>::deserialize(&self.identifier)?)
+    }
 }
 
 impl Config {

--- a/frostd/src/types.rs
+++ b/frostd/src/types.rs
@@ -1,6 +1,4 @@
-use frost_core::{
-    round1::SigningCommitments, round2::SignatureShare, Ciphersuite, Identifier, SigningPackage,
-};
+use frost_core::{Ciphersuite, SigningPackage};
 use frost_rerandomized::Randomizer;
 use serde::{Deserialize, Serialize};
 pub use uuid::Uuid;
@@ -144,15 +142,7 @@ pub struct CloseSessionArgs {
     pub session_id: Uuid,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(bound = "C: Ciphersuite")]
-pub struct SendCommitmentsArgs<C: Ciphersuite> {
-    pub identifier: Identifier<C>,
-    pub commitments: Vec<SigningCommitments<C>>,
-}
-
 #[derive(Serialize, Deserialize, derivative::Derivative)]
-#[derivative(Debug)]
 #[serde(bound = "C: Ciphersuite")]
 pub struct SendSigningPackageArgs<C: Ciphersuite> {
     pub signing_package: Vec<SigningPackage<C>>,
@@ -161,13 +151,5 @@ pub struct SendSigningPackageArgs<C: Ciphersuite> {
         deserialize_with = "serdect::slice::deserialize_hex_or_bin_vec"
     )]
     pub aux_msg: Vec<u8>,
-    #[derivative(Debug = "ignore")]
     pub randomizer: Vec<Randomizer<C>>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(bound = "C: Ciphersuite")]
-pub struct SendSignatureSharesArgs<C: Ciphersuite> {
-    pub identifier: Identifier<C>,
-    pub signature_share: Vec<SignatureShare<C>>,
 }

--- a/frostd/tests/integration_tests.rs
+++ b/frostd/tests/integration_tests.rs
@@ -60,9 +60,7 @@ async fn test_main_router<
     let router = router(shared_state);
     let server = TestServer::new(router)?;
 
-    // Create a dummy user. We make all requests with the same user since
-    // it currently it doesn't really matter who the user is, users are only
-    // used to share session IDs. This will likely change soon.
+    // Log in as two different users, Alice and Bob
 
     let builder = snow::Builder::new("Noise_K_25519_ChaChaPoly_BLAKE2s".parse().unwrap());
     let alice_keypair = builder.generate_keypair().unwrap();
@@ -180,16 +178,12 @@ async fn test_main_router<
     }
 
     // As the coordinator, get the commitments
-    let pubkey_identifier_map = HashMap::from([
-        (
-            alice_keypair.public.clone(),
-            *key_packages.first_key_value().unwrap().0,
-        ),
-        (
-            bob_keypair.public.clone(),
-            *key_packages.last_key_value().unwrap().0,
-        ),
-    ]);
+    let comm_pubkeys = [&alice_keypair.public, &bob_keypair.public];
+    let pubkey_identifier_map = comm_pubkeys
+        .into_iter()
+        .cloned()
+        .zip(key_packages.keys().take(2).copied())
+        .collect::<HashMap<_, _>>();
     let mut coordinator_state = SessionState::<C>::new(2, 2, pubkey_identifier_map);
     loop {
         let res = server

--- a/participant/src/comms/http.rs
+++ b/participant/src/comms/http.rs
@@ -111,7 +111,7 @@ pub struct HTTPComms<C: Ciphersuite> {
     _phantom: PhantomData<C>,
 }
 
-use frostd::{SendCommitmentsArgs, SendSignatureSharesArgs, SendSigningPackageArgs, Uuid};
+use frostd::{SendSigningPackageArgs, Uuid};
 
 // TODO: Improve error handling for invalid session id
 impl<C> HTTPComms<C>
@@ -168,7 +168,7 @@ where
         _input: &mut dyn BufRead,
         _output: &mut dyn Write,
         commitments: SigningCommitments<C>,
-        identifier: Identifier<C>,
+        _identifier: Identifier<C>,
         rerandomized: bool,
     ) -> Result<
         (
@@ -250,9 +250,7 @@ where
             );
         };
 
-        // If encryption is enabled, create the Noise objects
-
-        // We need to know what is the username of the coordinator in order
+        // We need to know what is the pubkey of the coordinator in order
         // to encrypt message to them.
         let session_info = self
             .client
@@ -291,10 +289,7 @@ where
         self.recv_noise = Some(recv_noise);
 
         // Send Commitments to Server
-        let send_commitments_args = SendCommitmentsArgs {
-            identifier,
-            commitments: vec![commitments],
-        };
+        let send_commitments_args = vec![commitments];
         let msg = self.encrypt(serde_json::to_vec(&send_commitments_args)?)?;
         self.client
             .post(format!("{}/send", self.host_port))
@@ -354,17 +349,14 @@ where
 
     async fn send_signature_share(
         &mut self,
-        identifier: Identifier<C>,
+        _identifier: Identifier<C>,
         signature_share: SignatureShare<C>,
     ) -> Result<(), Box<dyn Error>> {
         // Send signature share to Coordinator
 
         eprintln!("Sending signature share to coordinator...");
 
-        let send_signature_shares_args = SendSignatureSharesArgs {
-            identifier,
-            signature_share: vec![signature_share],
-        };
+        let send_signature_shares_args = vec![signature_share];
 
         let msg = self.encrypt(serde_json::to_vec(&send_signature_shares_args)?)?;
 


### PR DESCRIPTION
Based on #423 

Closes #429 

Before authentication we were sending identifiers between coordinator and participants to identify peers, but that's insecure; we forgot to change it after we added authentication.

This changes the coordinator and participant to not send identifiers along with messages.