### PR TITLE
frost-client: fix error if there is no self contact

### DIFF
--- a/frost-client/src/config.rs
+++ b/frost-client/src/config.rs
@@ -30,6 +30,13 @@ pub struct Config {
 
 impl Config {
     pub fn contact_by_pubkey(&self, pubkey: &[u8]) -> Result<Contact, Box<dyn Error>> {
+        if Some(pubkey) == self.communication_key.as_ref().map(|c| c.pubkey.as_slice()) {
+            return Ok(Contact {
+                version: Some(0),
+                name: "".to_string(),
+                pubkey: pubkey.to_vec(),
+            });
+        }
         Ok(self
             .contact
             .values()


### PR DESCRIPTION
While documenting the demo I found a bug; if you initialize fresh configs and run the DKG, it would fail, because it does not create a "self contact (i.e. a contact with your own public key), unlike what `trusted-dealer` does.

I think `trusted-dealer` is wrong (but it's harmless) and a "self contact" should not be required. This changes `contact_by_pubkey()` to also search for the self pubkey. It puts an empty as the string, which is harmless enough (it makes  an empty string appear in `frost-client sessions` for example, which we could handle better later).