### PR TITLE
frost-client: fix port handling

### DIFF
--- a/frost-client/src/coordinator.rs
+++ b/frost-client/src/coordinator.rs
@@ -89,7 +89,9 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
             .host_str()
             .ok_or_eyre("host missing in URL")?
             .to_owned(),
-        port: server_url_parsed.port().unwrap_or(2744),
+        port: server_url_parsed
+            .port_or_known_default()
+            .expect("always works for https"),
         comm_privkey: Some(
             config
                 .communication_key

--- a/frost-client/src/participant.rs
+++ b/frost-client/src/participant.rs
@@ -72,7 +72,9 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
             .host_str()
             .ok_or_eyre("host missing in URL")?
             .to_owned(),
-        port: server_url_parsed.port().unwrap_or(2744),
+        port: server_url_parsed
+            .port_or_known_default()
+            .expect("always works for https"),
         session_id: session.unwrap_or_default(),
         comm_privkey: Some(
             config


### PR DESCRIPTION
`--server-url localhost:443` would wrongly use port `2744`.

The reason is that  `Url::port()` weirdly returns `None` even if port `443` is explicitly specified. This PR fixes that by switching to `port_or_known_default()`.

Note that per its docs `port_or_known_default()` always returns `Some(x)` if the protocol is known, which we know it is since we prepend `https://` to the user specified host before calling `parse()`.

This also ends up turning `443` into the default which is probably the right thing for regular usage.