### PR TITLE
Fix max_signers retrieval in CLIComms

### DIFF
--- a/dkg/src/cli.rs
+++ b/dkg/src/cli.rs
@@ -91,7 +91,7 @@ pub async fn cli_for_processed_args<C: Ciphersuite + 'static + MaybeIntoEvenY>(
 
     let rng = thread_rng();
 
-    let (identifier, max_signers) = comms.get_identifier(input, logger).await?;
+    let (identifier, max_signers) = comms.get_identifier_and_max_signers(input, logger).await?;
 
     let (round1_secret_package, round1_package) =
         frost::keys::dkg::part1(identifier, max_signers, pargs.min_signers, rng)?;

--- a/dkg/src/comms.rs
+++ b/dkg/src/comms.rs
@@ -21,7 +21,7 @@ use frost::Identifier;
 pub trait Comms<C: Ciphersuite> {
     /// Return this participant's identifier (in case it's derived from other
     /// information) and the number of participants in the signing session.
-    async fn get_identifier(
+    async fn get_identifier_and_max_signers(
         &mut self,
         input: &mut dyn BufRead,
         output: &mut dyn Write,

--- a/dkg/src/comms/cli.rs
+++ b/dkg/src/comms/cli.rs
@@ -45,7 +45,7 @@ impl<C> Comms<C> for CLIComms<C>
 where
     C: Ciphersuite + 'static,
 {
-    async fn get_identifier(
+    async fn get_identifier_and_max_signers(
         &mut self,
         _input: &mut dyn BufRead,
         _output: &mut dyn Write,
@@ -54,7 +54,9 @@ where
             self.args
                 .identifier
                 .ok_or_eyre("identifier must be specified")?,
-            0,
+            self.args
+                .max_signers
+                .ok_or_eyre("max_signers must be specified")?,
         ))
     }
 

--- a/dkg/src/comms/http.rs
+++ b/dkg/src/comms/http.rs
@@ -424,7 +424,7 @@ impl<C: Ciphersuite> HTTPComms<C> {
 
 #[async_trait(?Send)]
 impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
-    async fn get_identifier(
+    async fn get_identifier_and_max_signers(
         &mut self,
         _input: &mut dyn BufRead,
         _output: &mut dyn Write,


### PR DESCRIPTION
`max_signers` was hard-coded to zero in `CLIComms`. This resulted in failure when running CLI DKG demo.

Also method `get_identifier` is renamed into `get_identifier_and_max_signers` to reflect better what it does