### PR TITLE
frost-client, frostd: show message to gather consent; overall printing clean up; fix sessions

### DIFF
--- a/coordinator/src/cli.rs
+++ b/coordinator/src/cli.rs
@@ -26,8 +26,6 @@ pub async fn cli_for_processed_args<C: RandomizedCiphersuite + 'static>(
     reader: &mut impl BufRead,
     logger: &mut impl Write,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    writeln!(logger, "\n=== STEP 1: CHOOSE PARTICIPANTS ===\n")?;
-
     let mut comms: Box<dyn Comms<C>> = if pargs.cli {
         Box::new(CLIComms::new())
     } else if pargs.http {
@@ -38,14 +36,7 @@ pub async fn cli_for_processed_args<C: RandomizedCiphersuite + 'static>(
 
     let participants_config = step_1(&pargs, &mut *comms, reader, logger).await?;
 
-    writeln!(
-        logger,
-        "=== STEP 2: CHOOSE MESSAGE AND GENERATE COMMITMENT PACKAGE ===\n"
-    )?;
-
     let signing_package = step_2(&pargs, logger, participants_config.commitments.clone())?;
-
-    writeln!(logger, "=== STEP 3: BUILD GROUP SIGNATURE ===\n")?;
 
     step_3(
         &pargs,
@@ -56,8 +47,6 @@ pub async fn cli_for_processed_args<C: RandomizedCiphersuite + 'static>(
         &signing_package,
     )
     .await?;
-
-    writeln!(logger, "=== END ===")?;
 
     Ok(())
 }

--- a/coordinator/src/comms/http.rs
+++ b/coordinator/src/comms/http.rs
@@ -341,6 +341,8 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
         _num_signers: u16,
     ) -> Result<BTreeMap<Identifier<C>, SigningCommitments<C>>, Box<dyn Error>> {
         let mut rng = thread_rng();
+
+        eprintln!("Logging in...");
         let challenge = self
             .client
             .post(format!("{}/challenge", self.host_port))
@@ -382,6 +384,7 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
                 .to_string(),
         );
 
+        eprintln!("Creating signing session...");
         let r = self
             .client
             .post(format!("{}/create_new_session", self.host_port))
@@ -555,6 +558,8 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
                 session_id: self.session_id.unwrap(),
             })
             .send()
+            .await?
+            .bytes()
             .await?;
 
         let _r = self
@@ -566,6 +571,8 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
                     .expect("must have been set before"),
             )
             .send()
+            .await?
+            .bytes()
             .await?;
 
         let signature_shares = self.state.signature_shares()?;

--- a/coordinator/src/step_1.rs
+++ b/coordinator/src/step_1.rs
@@ -23,7 +23,9 @@ pub async fn step_1<C: Ciphersuite>(
     logger: &mut dyn Write,
 ) -> Result<ParticipantsConfig<C>, Box<dyn std::error::Error>> {
     let participants = read_commitments(args, comms, reader, logger).await?;
-    print_participants(logger, &participants.commitments);
+    if args.cli {
+        print_participants(logger, &participants.commitments);
+    }
     Ok(participants)
 }
 

--- a/coordinator/src/step_2.rs
+++ b/coordinator/src/step_2.rs
@@ -18,7 +18,9 @@ pub fn step_2<C: Ciphersuite>(
     commitments: BTreeMap<Identifier<C>, SigningCommitments<C>>,
 ) -> Result<SigningPackage<C>, Box<dyn std::error::Error>> {
     let signing_package = SigningPackage::new(commitments, &args.messages[0]);
-    print_signing_package(logger, &signing_package);
+    if args.cli {
+        print_signing_package(logger, &signing_package);
+    }
     Ok(signing_package)
 }
 

--- a/coordinator/src/step_3.rs
+++ b/coordinator/src/step_3.rs
@@ -85,8 +85,8 @@ fn print_signature<C: Ciphersuite + 'static>(
     if args.signature.is_empty() {
         writeln!(
             logger,
-            "Group signature: {}",
-            serde_json::to_string(&group_signature)?
+            "Signature:\n{}",
+            hex::encode(&group_signature.serialize()?)
         )?;
     } else {
         fs::write(&args.signature, group_signature.serialize()?)?;

--- a/coordinator/src/tests/steps.rs
+++ b/coordinator/src/tests/steps.rs
@@ -142,7 +142,10 @@ async fn check_step_2() {
         ..
     } = get_helpers();
 
-    let args = Args::default();
+    let args = Args {
+        cli: true,
+        ..Default::default()
+    };
     let mut buf = BufWriter::new(Vec::new());
 
     let input = format!(
@@ -228,7 +231,7 @@ async fn check_step_3() {
     .await
     .unwrap();
 
-    let expected = format!("Please enter JSON encoded signature shares for participant {}:\nPlease enter JSON encoded signature shares for participant {}:\nGroup signature: \"{}\"\n", participant_id_1, participant_id_3, group_signature);
+    let expected = format!("Please enter JSON encoded signature shares for participant {}:\nPlease enter JSON encoded signature shares for participant {}:\nSignature:\n{}\n", participant_id_1, participant_id_3, group_signature);
 
     let (_, res) = &buf.into_parts();
     let actual = String::from_utf8(res.as_ref().unwrap().to_owned()).unwrap();

--- a/dkg/src/comms/http.rs
+++ b/dkg/src/comms/http.rs
@@ -430,6 +430,8 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
         _output: &mut dyn Write,
     ) -> Result<(Identifier<C>, u16), Box<dyn Error>> {
         let mut rng = thread_rng();
+
+        eprintln!("Logging in...");
         let challenge = self
             .client
             .post(format!("{}/challenge", self.host_port))
@@ -473,6 +475,7 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
         );
 
         let session_id = if !self.args.participants.is_empty() {
+            eprintln!("Creating DKG session...");
             let r = self
                 .client
                 .post(format!("{}/create_new_session", self.host_port))
@@ -493,6 +496,7 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
                 .await?;
             r.session_id
         } else {
+            eprintln!("Joining DKG session...");
             match self.session_id {
                 Some(s) => s,
                 None => {
@@ -516,6 +520,7 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
         };
         self.session_id = Some(session_id);
 
+        eprintln!("Getting session info...");
         // Get all participants' public keys, and derive their identifiers
         // from them.
         let session_info = self

--- a/frost-client/src/args.rs
+++ b/frost-client/src/args.rs
@@ -146,6 +146,10 @@ pub(crate) enum Command {
         /// by the group public key (use `groups` to list).
         #[arg(short, long)]
         group: Option<String>,
+        /// Whether to also close all existing sessions. Useful for cleaning
+        /// up lingering sessions due to errors or if participants give up.
+        #[arg(long, default_value_t = false)]
+        close_all: bool,
     },
     Coordinator {
         /// The path to the config file to manage. If not specified, it uses

--- a/frost-client/src/dkg.rs
+++ b/frost-client/src/dkg.rs
@@ -137,5 +137,10 @@ pub(crate) async fn dkg_for_ciphersuite<C: Ciphersuite + MaybeIntoEvenY + 'stati
     );
     config.write()?;
 
+    eprintln!(
+        "Group created; information written to {}",
+        config.path().expect("should not be None").display()
+    );
+
     Ok(())
 }

--- a/frost-client/src/session.rs
+++ b/frost-client/src/session.rs
@@ -11,6 +11,7 @@ pub(crate) async fn list(args: &Command) -> Result<(), Box<dyn Error>> {
         config,
         group,
         server_url,
+        close_all,
     } = (*args).clone()
     else {
         panic!("invalid Command");
@@ -124,6 +125,17 @@ pub(crate) async fn list(args: &Command) -> Result<(), Box<dyn Error>> {
                 }
             }
             eprintln!();
+
+            if close_all {
+                let _r = client
+                    .post(format!("{}/close_session", host_port))
+                    .bearer_auth(&access_token)
+                    .json(&frostd::CloseSessionArgs { session_id })
+                    .send()
+                    .await?
+                    .bytes()
+                    .await?;
+            }
         }
     }
 

--- a/participant/src/comms/http.rs
+++ b/participant/src/comms/http.rs
@@ -178,6 +178,8 @@ where
         Box<dyn Error>,
     > {
         let mut rng = thread_rng();
+
+        eprintln!("Logging in...");
         let challenge = self
             .client
             .post(format!("{}/challenge", self.host_port))
@@ -219,6 +221,7 @@ where
                 .to_string(),
         );
 
+        eprintln!("Joining signing session...");
         let session_id = match self.session_id {
             Some(s) => s,
             None => {
@@ -289,6 +292,7 @@ where
         self.recv_noise = Some(recv_noise);
 
         // Send Commitments to Server
+        eprintln!("Sending commitments to coordinator...");
         let send_commitments_args = vec![commitments];
         let msg = self.encrypt(serde_json::to_vec(&send_commitments_args)?)?;
         self.client
@@ -326,7 +330,6 @@ where
             } else {
                 eprintln!("\nSigning package received");
                 let msg = self.decrypt(r.msgs[0].msg.clone())?;
-                eprintln!("\n{}", String::from_utf8_lossy(&msg.clone()));
                 break serde_json::from_slice(&msg)?;
             }
         };

--- a/participant/src/round2.rs
+++ b/participant/src/round2.rs
@@ -25,8 +25,6 @@ pub async fn round_2_request_inputs<C: Ciphersuite>(
     identifier: Identifier<C>,
     rerandomized: bool,
 ) -> Result<Round2Config<C>, Box<dyn std::error::Error>> {
-    writeln!(logger, "=== Round 2 ===")?;
-
     let r = comms
         .get_signing_package(input, logger, commitments, identifier, rerandomized)
         .await?;
@@ -62,7 +60,6 @@ pub fn print_values_round_2<C: Ciphersuite>(
         "SignatureShare:\n{}",
         serde_json::to_string(&signature).unwrap()
     )?;
-    writeln!(logger, "=== End of Round 2 ===")?;
 
     Ok(())
 }

--- a/participant/src/tests/round2.rs
+++ b/participant/src/tests/round2.rs
@@ -141,7 +141,7 @@ async fn check_print_values_round_2() {
 
     print_values_round_2(signature_response, &mut buf).unwrap();
 
-    let log = "Please send the following to the Coordinator\nSignatureShare:\n{\"header\":{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"},\"share\":\"44055c54d0604cbd006f0d1713a22474d7735c5e8816b1878f62ca94bf105900\"}\n=== End of Round 2 ===\n";
+    let log = "Please send the following to the Coordinator\nSignatureShare:\n{\"header\":{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"},\"share\":\"44055c54d0604cbd006f0d1713a22474d7735c5e8816b1878f62ca94bf105900\"}\n";
 
     let out = String::from_utf8(buf.into_inner().unwrap()).unwrap();
 


### PR DESCRIPTION
- Add a prompt that shows the message before signing and asks for consent to proceed;
- Clean up prints in general
- Add a flag to allow closing all existing sessions
- Fix a bug in the server that would prevent listing sessions where you are the coordinator but not a signer