### PR TITLE
frost-client: don't allow overwriting contacts

### DIFF
--- a/frost-client/src/contact.rs
+++ b/frost-client/src/contact.rs
@@ -83,6 +83,13 @@ pub(crate) fn import(args: &Command) -> Result<(), Box<dyn Error>> {
         )
         .into());
     }
+    if config.communication_key.as_ref().map(|c| &c.pubkey) == Some(&contact.pubkey) {
+        return Err(eyre!(
+            "pubkey {} already registered for yourself",
+            hex::encode(&contact.pubkey)
+        )
+        .into());
+    }
     // We don't want the version when writing to the config file.
     contact.version = None;
     config.contact.insert(contact.name.clone(), contact.clone());

--- a/frost-client/src/contact.rs
+++ b/frost-client/src/contact.rs
@@ -67,6 +67,22 @@ pub(crate) fn import(args: &Command) -> Result<(), Box<dyn Error>> {
     let mut config = Config::read(config)?;
 
     let mut contact = Contact::from_text(&text_contact)?;
+    if config.contact.contains_key(&contact.name) {
+        return Err(eyre!(
+            "contact with name {} already exists. Either remove the existing \
+            one, or ask the sender to change their display name when exporting",
+            &contact.name
+        )
+        .into());
+    }
+    if config.contact.values().any(|c| c.pubkey == contact.pubkey) {
+        return Err(eyre!(
+            "pubkey {} already registered for {}",
+            hex::encode(&contact.pubkey),
+            &contact.name,
+        )
+        .into());
+    }
     // We don't want the version when writing to the config file.
     contact.version = None;
     config.contact.insert(contact.name.clone(), contact.clone());


### PR DESCRIPTION
Closes #474 

I also added a check for duplicated pubkeys. Since we remove by pubkey, having two contacts with the same pubkey would lead to ambiguity, and it doesn't make sense anyway.

Tested manually.