### PR TITLE
frost-client: add trusted-dealer warnings

### DIFF
--- a/frost-client/src/args.rs
+++ b/frost-client/src/args.rs
@@ -54,7 +54,18 @@ pub(crate) enum Command {
         #[arg(short, long)]
         pubkey: String,
     },
-    /// Generate FROST shares using a trusted dealer.
+    /// Generate FROST shares using a trusted dealer. Should only be used for
+    /// tests.
+    ///
+    /// IMPORTANT: this should only be used for tests. After a trusted dealer
+    /// key generation, the participant need to validate their received shares
+    /// before generating a key package. This tool does not do that and writes
+    /// just the key packages into the config files, making it impossible for
+    /// participants to verify them since the required information is lost.
+    ///
+    /// A future version of this tool might support running the trusted dealer
+    /// using the FROST server; but there is no benefit in doing that instead of
+    /// using distributed key generation (DKG).
     TrustedDealer {
         /// The path to the config file to manage.
         ///
@@ -151,6 +162,7 @@ pub(crate) enum Command {
         #[arg(long, default_value_t = false)]
         close_all: bool,
     },
+    /// Start a new FROST signing session.
     Coordinator {
         /// The path to the config file to manage. If not specified, it uses
         /// $HOME/.local/frost/credentials.toml
@@ -186,6 +198,7 @@ pub(crate) enum Command {
         #[arg(short = 'o', long, default_value = "")]
         signature: String,
     },
+    /// Participate in a FROST signing session.
     Participant {
         /// The path to the config file to manage. If not specified, it uses
         /// $HOME/.local/frost/credentials.toml

--- a/frost-client/src/args.rs
+++ b/frost-client/src/args.rs
@@ -58,7 +58,7 @@ pub(crate) enum Command {
     /// tests.
     ///
     /// IMPORTANT: this should only be used for tests. After a trusted dealer
-    /// key generation, the participant need to validate their received shares
+    /// key generation, the participants need to validate their received shares
     /// before generating a key package. This tool does not do that and writes
     /// just the key packages into the config files, making it impossible for
     /// participants to verify them since the required information is lost.

--- a/frost-client/src/trusted_dealer.rs
+++ b/frost-client/src/trusted_dealer.rs
@@ -89,6 +89,12 @@ pub(crate) fn trusted_dealer_for_ciphersuite<C: Ciphersuite + MaybeIntoEvenY + '
     // Second pass over configs; write group information
     for (share, path) in shares.values().zip(config.iter()) {
         let mut config = Config::read(Some(path.to_string()))?;
+        // IMPORTANT: the TrustedDealer command intended for tests only, see
+        // comment in [`Command::TrustedDealer`]. If you're using this code as a
+        // reference, note that participants should not convert a SecretShare
+        // into a KeyPackage without first checking if
+        // [`SecretShare::commitment()`] is the same for all participants using
+        // a broadcast channel.
         let key_package: KeyPackage<C> = share.clone().try_into()?;
         let group = Group {
             ciphersuite: C::ID.to_string(),

--- a/frost-client/src/trusted_dealer.rs
+++ b/frost-client/src/trusted_dealer.rs
@@ -89,7 +89,7 @@ pub(crate) fn trusted_dealer_for_ciphersuite<C: Ciphersuite + MaybeIntoEvenY + '
     // Second pass over configs; write group information
     for (share, path) in shares.values().zip(config.iter()) {
         let mut config = Config::read(Some(path.to_string()))?;
-        // IMPORTANT: the TrustedDealer command intended for tests only, see
+        // IMPORTANT: the TrustedDealer command is intended for tests only, see
         // comment in [`Command::TrustedDealer`]. If you're using this code as a
         // reference, note that participants should not convert a SecretShare
         // into a KeyPackage without first checking if


### PR DESCRIPTION
Closes #472 

We do not address the finding directly. Rationale:

As it stands, we believe the suggested check wouldn't be meaningful. Only after receiving the config files would the participants need to verify the commitments, which happens outside of the tool; additionally, that requires the commitments which are not stored in the config file. We believe it also does not make sense to include the check for reference because that requires a broadcast channel which is complicated to setup. We decided to instead add warnings on the command line help and in the source code.