### PR TITLE
frost-client: add message confirmation step to Comms trait

### DIFF
--- a/participant/src/cli.rs
+++ b/participant/src/cli.rs
@@ -69,6 +69,10 @@ pub async fn cli_for_processed_args<C: RandomizedCiphersuite + 'static>(
     )
     .await?;
 
+    comms
+        .confirm_message(input, logger, &round_2_config)
+        .await?;
+
     let signature = generate_signature(round_2_config, &key_package, &nonces)?;
 
     comms

--- a/participant/src/cli.rs
+++ b/participant/src/cli.rs
@@ -8,7 +8,7 @@ use crate::comms::Comms;
 
 use crate::round1::{generate_nonces_and_commitments, print_values};
 use crate::round2::{generate_signature, print_values_round_2, round_2_request_inputs};
-use eyre::eyre;
+
 use frost_core::Ciphersuite;
 use frost_ed25519::Ed25519Sha512;
 use frost_rerandomized::RandomizedCiphersuite;
@@ -68,17 +68,6 @@ pub async fn cli_for_processed_args<C: RandomizedCiphersuite + 'static>(
         rerandomized,
     )
     .await?;
-
-    writeln!(
-        logger,
-        "Message to be signed (hex-encoded):\n{}\nDo you want to sign it? (y/n)",
-        hex::encode(round_2_config.signing_package.message())
-    )?;
-    let mut sign_it = String::new();
-    input.read_line(&mut sign_it)?;
-    if sign_it.trim() != "y" {
-        return Err(eyre!("signing cancelled").into());
-    }
 
     let signature = generate_signature(round_2_config, &key_package, &nonces)?;
 

--- a/participant/src/comms/cli.rs
+++ b/participant/src/comms/cli.rs
@@ -10,6 +10,7 @@ use frost::{
     keys::PublicKeyPackage, round1::SigningCommitments, round2::SignatureShare, Identifier,
     SigningPackage,
 };
+use frostd::SendSigningPackageArgs;
 
 use std::{
     error::Error,
@@ -47,13 +48,7 @@ where
         _commitments: SigningCommitments<C>,
         _identifier: Identifier<C>,
         rerandomized: bool,
-    ) -> Result<
-        (
-            frost::SigningPackage<C>,
-            Option<frost_rerandomized::Randomizer<C>>,
-        ),
-        Box<dyn Error>,
-    > {
+    ) -> Result<SendSigningPackageArgs<C>, Box<dyn Error>> {
         writeln!(output, "Enter the JSON-encoded SigningPackage:")?;
 
         let mut signing_package_json = String::new();
@@ -71,9 +66,19 @@ where
 
             let randomizer =
                 frost_rerandomized::Randomizer::<C>::deserialize(&hex::decode(json.trim())?)?;
-            Ok((signing_package, Some(randomizer)))
+            let r = frostd::SendSigningPackageArgs::<C> {
+                signing_package: vec![signing_package],
+                randomizer: vec![randomizer],
+                aux_msg: vec![],
+            };
+            Ok(r)
         } else {
-            Ok((signing_package, None))
+            let r = frostd::SendSigningPackageArgs::<C> {
+                signing_package: vec![signing_package],
+                randomizer: vec![],
+                aux_msg: vec![],
+            };
+            Ok(r)
         }
     }
 

--- a/participant/src/comms/http.rs
+++ b/participant/src/comms/http.rs
@@ -9,9 +9,7 @@ use std::{
 
 use async_trait::async_trait;
 use eyre::{eyre, OptionExt};
-use frost_core::{
-    self as frost, round1::SigningCommitments, round2::SignatureShare, Ciphersuite, Identifier,
-};
+use frost_core::{round1::SigningCommitments, round2::SignatureShare, Ciphersuite, Identifier};
 use rand::thread_rng;
 use snow::{HandshakeState, TransportState};
 use xeddsa::{xed25519, Sign as _};
@@ -169,14 +167,8 @@ where
         _output: &mut dyn Write,
         commitments: SigningCommitments<C>,
         _identifier: Identifier<C>,
-        rerandomized: bool,
-    ) -> Result<
-        (
-            frost::SigningPackage<C>,
-            Option<frost_rerandomized::Randomizer<C>>,
-        ),
-        Box<dyn Error>,
-    > {
+        _rerandomized: bool,
+    ) -> Result<SendSigningPackageArgs<C>, Box<dyn Error>> {
         let mut rng = thread_rng();
 
         eprintln!("Logging in...");
@@ -334,20 +326,7 @@ where
             }
         };
 
-        if rerandomized {
-            let signing_package = r
-                .signing_package
-                .first()
-                .ok_or(eyre!("missing signing package"))?;
-            let randomizer = r.randomizer.first().ok_or(eyre!("missing randomizer"))?;
-            Ok((signing_package.clone(), Some(*randomizer)))
-        } else {
-            let signing_package = r
-                .signing_package
-                .first()
-                .ok_or(eyre!("missing signing package"))?;
-            Ok((signing_package.clone(), None))
-        }
+        Ok(r)
     }
 
     async fn send_signature_share(

--- a/participant/src/tests/round2.rs
+++ b/participant/src/tests/round2.rs
@@ -11,6 +11,7 @@ use frost::{
     round2::SignatureShare,
     SigningPackage, VerifyingKey,
 };
+use frostd::SendSigningPackageArgs;
 use hex::FromHex;
 use participant::comms::cli::CLIComms;
 use participant::round2::print_values_round_2;
@@ -82,7 +83,7 @@ async fn check_valid_round_2_inputs() {
     assert!(round_2_config.is_ok());
     assert_eq!(
         expected.signing_package,
-        round_2_config.unwrap().signing_package
+        round_2_config.unwrap().signing_package[0]
     )
 }
 
@@ -120,9 +121,10 @@ async fn check_sign() {
 
     let signing_package = SigningPackage::new(signer_commitments, message);
 
-    let config = Round2Config {
-        signing_package,
-        randomizer: None,
+    let config = SendSigningPackageArgs {
+        signing_package: vec![signing_package],
+        randomizer: vec![],
+        aux_msg: vec![],
     };
 
     let signature = generate_signature(config, &key_package, &nonces);

--- a/participant/tests/integration_tests.rs
+++ b/participant/tests/integration_tests.rs
@@ -1,10 +1,12 @@
 use std::collections::{BTreeMap, HashMap};
+use std::vec;
 
 use frost_ed25519 as frost;
 
 use frost::keys::IdentifierList;
 use frost::{aggregate, SigningPackage};
-use participant::round2::{generate_signature, Round2Config};
+use frostd::SendSigningPackageArgs;
+use participant::round2::generate_signature;
 use rand::thread_rng;
 
 #[test]
@@ -40,9 +42,10 @@ fn check_participant() {
     let mut signature_shares = BTreeMap::new();
 
     for participant_identifier in nonces.keys() {
-        let config = Round2Config {
-            signing_package: SigningPackage::new(commitments.clone(), &message),
-            randomizer: None,
+        let config = SendSigningPackageArgs {
+            signing_package: vec![SigningPackage::new(commitments.clone(), &message)],
+            randomizer: vec![],
+            aux_msg: vec![],
         };
         let signature = generate_signature(
             config,


### PR DESCRIPTION
Closes #476 

I also did a small cleanup of passing `SendSigningPackageArgs` around instead of just `SigningPackage` since the former will actually have all the information the user needs to confirm what they're signing.

We don't address it exactly as suggested; rationale:

> Since the tool is not aware of the protocol using it it's not possible to do the verification itself. However, it's important to show the user what they're signing and ask them if they really want to sign the message. We introduce that along with a trait method similar to what was suggested. In the context of Zcash, this will be amended later to show the transaction plan of the transaction being signed. At that point we will likely introduce some Content-Type data that will allow the user to understand what kind of data they are signing.

I've edited https://github.com/ZcashFoundation/frost-zcash-demo/issues/333 to reflect some of these details.
