### PR TITLE
frostd, dkg, coordinator: check msg size; cleanup on error

### DIFF
--- a/coordinator/src/comms.rs
+++ b/coordinator/src/comms.rs
@@ -53,4 +53,9 @@ pub trait Comms<C: Ciphersuite> {
         signing_package: &SigningPackage<C>,
         randomizer: Option<frost_rerandomized::Randomizer<C>>,
     ) -> Result<BTreeMap<Identifier<C>, SignatureShare<C>>, Box<dyn Error>>;
+
+    /// Do any cleanups in case an error occurs during the protocol run.
+    async fn cleanup_on_error(&mut self) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
 }

--- a/coordinator/src/step_1.rs
+++ b/coordinator/src/step_1.rs
@@ -15,7 +15,6 @@ pub struct ParticipantsConfig<C: Ciphersuite> {
     pub pub_key_package: PublicKeyPackage<C>,
 }
 
-// TODO: needs to include the coordinator's keys!
 pub async fn step_1<C: Ciphersuite>(
     args: &ProcessedArgs<C>,
     comms: &mut dyn Comms<C>,

--- a/dkg/src/cli.rs
+++ b/dkg/src/cli.rs
@@ -90,31 +90,41 @@ pub async fn cli_for_processed_args<C: Ciphersuite + 'static + MaybeIntoEvenY>(
         return Err(eyre!("either --cli or --http must be specified").into());
     };
 
-    let rng = thread_rng();
+    // We put the main logic on a block to be able to cleanup if an error is
+    // returned anywhere in it.
+    let doit = async {
+        let rng = thread_rng();
 
-    let (identifier, max_signers) = comms.get_identifier_and_max_signers(input, logger).await?;
+        let (identifier, max_signers) = comms.get_identifier_and_max_signers(input, logger).await?;
 
-    let (round1_secret_package, round1_package) =
-        frost::keys::dkg::part1(identifier, max_signers, pargs.min_signers, rng)?;
+        let (round1_secret_package, round1_package) =
+            frost::keys::dkg::part1(identifier, max_signers, pargs.min_signers, rng)?;
 
-    let received_round1_packages = comms
-        .get_round1_packages(input, logger, round1_package)
-        .await?;
+        let received_round1_packages = comms
+            .get_round1_packages(input, logger, round1_package)
+            .await?;
 
-    let (round2_secret_package, round2_packages) =
-        frost::keys::dkg::part2(round1_secret_package, &received_round1_packages)?;
+        let (round2_secret_package, round2_packages) =
+            frost::keys::dkg::part2(round1_secret_package, &received_round1_packages)?;
 
-    let received_round2_packages = comms
-        .get_round2_packages(input, logger, round2_packages)
-        .await?;
+        let received_round2_packages = comms
+            .get_round2_packages(input, logger, round2_packages)
+            .await?;
 
-    let (key_package, public_key_package) = MaybeIntoEvenY::into_even_y(frost::keys::dkg::part3(
-        &round2_secret_package,
-        &received_round1_packages,
-        &received_round2_packages,
-    )?);
+        let (key_package, public_key_package) =
+            MaybeIntoEvenY::into_even_y(frost::keys::dkg::part3(
+                &round2_secret_package,
+                &received_round1_packages,
+                &received_round2_packages,
+            )?);
 
-    let pubkey_map = comms.get_pubkey_identifier_map()?;
+        let pubkey_map = comms.get_pubkey_identifier_map()?;
+        Ok((key_package, public_key_package, pubkey_map))
+    };
 
-    Ok((key_package, public_key_package, pubkey_map))
+    let r = doit.await;
+    if r.is_err() {
+        let _ = comms.cleanup_on_error().await;
+    }
+    r
 }

--- a/dkg/src/comms.rs
+++ b/dkg/src/comms.rs
@@ -50,4 +50,9 @@ pub trait Comms<C: Ciphersuite> {
     fn get_pubkey_identifier_map(
         &self,
     ) -> Result<HashMap<PublicKey, Identifier<C>>, Box<dyn Error>>;
+
+    /// Do any cleanups in case an error occurs during the protocol run.
+    async fn cleanup_on_error(&mut self) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
 }

--- a/frostd/src/functions.rs
+++ b/frostd/src/functions.rs
@@ -170,6 +170,10 @@ pub(crate) async fn send(
     user: User,
     Json(args): Json<SendArgs>,
 ) -> Result<(), AppError> {
+    if args.msg.len() > MAX_MSG_SIZE {
+        return Err(AppError::InvalidArgument("msg is too big".into()));
+    }
+
     // Get the mutex lock to read and write from the state
     let mut sessions = state.sessions.sessions.write().unwrap();
 

--- a/frostd/src/types.rs
+++ b/frostd/src/types.rs
@@ -3,6 +3,9 @@ use frost_rerandomized::Randomizer;
 use serde::{Deserialize, Serialize};
 pub use uuid::Uuid;
 
+/// The maximum size of a message.
+pub const MAX_MSG_SIZE: usize = 65535;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Error {
     pub code: usize,

--- a/frostd/tests/integration_tests.rs
+++ b/frostd/tests/integration_tests.rs
@@ -418,6 +418,20 @@ async fn test_main_router<
     let r: frostd::Error = res.json();
     assert_eq!(r.code, frostd::NOT_IN_SESSION);
 
+    // Check if sending a too big message fails
+    let res = server
+        .post("/send")
+        .authorization_bearer(alice_token)
+        .json(&frostd::SendArgs {
+            session_id,
+            recipients: vec![frostd::PublicKey(alice_keypair.public.clone())],
+            msg: [0; frostd::MAX_MSG_SIZE + 1].to_vec(),
+        })
+        .await;
+    res.assert_status_internal_server_error();
+    let r: frostd::Error = res.json();
+    assert_eq!(r.code, frostd::INVALID_ARGUMENT);
+
     Ok(())
 }
 


### PR DESCRIPTION
Based on #485

Closes #480.

The issue is not addressed directly as suggested; rationale:

> FROST is not a robust protocol, meaning participants can always prevent a signing sessions from succeeding. For this reason, we don't actively try to prevent participants from being able to abort sessions; they can do that in a myriad of different ways like sending a invalid encrypted message. That being said, we did add a message limit check on the server to mitigate memory exhaustion (since otherwise the length would only be checked when someone receives and decrypts a message). We also added session cleanup in case of error for coordinator and DKG starter, to avoid having aborted sessions lingering in case of error during the protocol.