### PR TITLE
frost-client: add warning about unencrypted contents

### DIFF
--- a/frost-client/src/args.rs
+++ b/frost-client/src/args.rs
@@ -9,8 +9,12 @@ pub(crate) struct Args {
 
 #[derive(Subcommand, Clone)]
 pub(crate) enum Command {
-    /// Initializes the user, generating a communication key pair and saving
-    /// to the config file.
+    /// Initializes the user, generating a communication key pair and saving to
+    /// the config file.
+    ///
+    /// WARNING: the config file will contain your private FROST shares in
+    /// clear. Keep it safe and never share it with anyone. Future versions of
+    /// this tool might encrypt the config file.
     Init {
         /// The path to the config file to manage. If not specified, it uses
         /// $HOME/.local/frost/credentials.toml

--- a/frost-client/src/init.rs
+++ b/frost-client/src/init.rs
@@ -29,7 +29,11 @@ pub(crate) async fn init(args: &Command) -> Result<(), Box<dyn Error>> {
         config.path().expect("should not be None").display()
     );
     config.write()?;
-    eprintln!("Done.");
+    eprintln!(
+        "Done.\nWARNING: the config file will contain your private FROST shares in clear. \
+    Keep it safe and never share it with anyone. Future versions of this tool might encrypt \
+    the config file."
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Related to #481; does not fully address it, but we probably still want to address it later.

Rationale: 

> We agree this is important but we will need to think carefully about the design considering interoperability with other applications. We'll schedule this work for later and in the meantime will add warnings about the issue in the documentation.