### PR TITLE
frost-client: refactored coordinator to work better as API

### DIFF
--- a/frost-client/src/cli/args.rs
+++ b/frost-client/src/cli/args.rs
@@ -1,5 +1,7 @@
 use clap::{Parser, Subcommand};
 
+use crate::cli::coordinator::CoordinatorCommand;
+
 #[derive(Parser, Clone)]
 #[command(version, about, long_about = None)]
 pub struct Args {
@@ -7,7 +9,7 @@ pub struct Args {
     pub command: Command,
 }
 
-#[derive(Subcommand, Clone)]
+#[derive(Subcommand, Clone, Debug)]
 pub enum Command {
     /// Initializes the user, generating a communication key pair and saving to
     /// the config file.
@@ -167,41 +169,7 @@ pub enum Command {
         close_all: bool,
     },
     /// Start a new FROST signing session.
-    Coordinator {
-        /// The path to the config file to manage. If not specified, it uses
-        /// $HOME/.local/frost/credentials.toml
-        #[arg(short, long)]
-        config: Option<String>,
-        /// The server URL to use. If not specified, it will use the server URL
-        /// for the specified group, if any. It will use the username previously
-        /// logged in via the `login` subcommand for the given server.
-        #[arg(short, long)]
-        server_url: Option<String>,
-        /// The group to use, identified by the group public key (use `groups`
-        /// to list)
-        #[arg(short, long)]
-        group: String,
-        /// The comma-separated hex-encoded public keys of the signers to use.
-        #[arg(short = 'S', long, value_delimiter = ',')]
-        signers: Vec<String>,
-        /// The messages to sign. Each instance can be a file with the raw message,
-        /// "" or "-". If "" or "-" is specified, then it will be read from standard
-        /// input as a hex string. If none are passed, a single one will be read
-        /// from standard input as a hex string.
-        #[arg(short = 'm', long)]
-        message: Vec<String>,
-        /// The randomizers to use. Each instance can be a file with the raw
-        /// randomizer, "" or "-". If "" or "-" is specified, then it will be
-        /// read from standard input as a hex string. If none are passed, random
-        /// ones will be generated if the ciphersuite is redpallas. If one or
-        /// more are passed, the number should match the `message` parameter.
-        #[arg(short = 'r', long)]
-        randomizer: Vec<String>,
-        /// Where to write the generated raw bytes signature. If "-", the
-        /// human-readable hex-string is printed to stdout.
-        #[arg(short = 'o', long, default_value = "")]
-        signature: String,
-    },
+    Coordinator(CoordinatorCommand),
     /// Participate in a FROST signing session.
     Participant {
         /// The path to the config file to manage. If not specified, it uses

--- a/frost-client/src/cli/coordinator.rs
+++ b/frost-client/src/cli/coordinator.rs
@@ -163,7 +163,11 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
     let signature = cli::coordinator(&mut comms, pargs).await?;
 
     let serialized_signature = signature.serialize()?;
-    fs::write(&signature_fn, &serialized_signature)?;
-    eprintln!("Raw signature written to {}", &signature_fn);
+    if signature_fn.is_empty() || signature_fn == "-" {
+        println!("{}", hex::encode(&serialized_signature));
+    } else {
+        fs::write(&signature_fn, &serialized_signature)?;
+        eprintln!("Raw signature written to {}", &signature_fn);
+    }
     Ok(signature)
 }

--- a/frost-client/src/cli/coordinator.rs
+++ b/frost-client/src/cli/coordinator.rs
@@ -1,11 +1,14 @@
 use std::collections::HashMap;
 use std::error::Error;
+use std::fs;
 
 use eyre::eyre;
 use eyre::Context;
 use eyre::OptionExt;
+use frost_core::Signature;
 
 use crate::cipher::PublicKey;
+use crate::coordinator::comms::http::HTTPComms;
 use frost_core::keys::PublicKeyPackage;
 use frost_core::Ciphersuite;
 use frost_ed25519::Ed25519Sha512;
@@ -19,8 +22,44 @@ use crate::coordinator::cli;
 use super::args::Command;
 use super::config::Config;
 
-pub async fn run(args: &Command) -> Result<(), Box<dyn Error>> {
-    let Command::Coordinator { config, group, .. } = (*args).clone() else {
+#[derive(clap::Args, Clone, Debug)]
+pub struct CoordinatorCommand {
+    /// The path to the config file to manage. If not specified, it uses
+    /// $HOME/.local/frost/credentials.toml
+    #[arg(short, long)]
+    pub config: Option<String>,
+    /// The server URL to use. If not specified, it will use the server URL
+    /// for the specified group, if any.
+    #[arg(short, long)]
+    pub server_url: Option<String>,
+    /// The group to use, identified by the group public key (use `groups`
+    /// to list)
+    #[arg(short, long)]
+    pub group: String,
+    /// The comma-separated hex-encoded public keys of the signers to use.
+    #[arg(short = 'S', long, value_delimiter = ',')]
+    pub signers: Vec<String>,
+    /// The messages to sign. Each instance can be a file with the raw message,
+    /// "" or "-". If "" or "-" is specified, then it will be read from standard
+    /// input as a hex string. If none are passed, a single one will be read
+    /// from standard input as a hex string.
+    #[arg(short = 'm', long)]
+    pub message: Vec<String>,
+    /// The randomizers to use. Each instance can be a file with the raw
+    /// randomizer, "" or "-". If "" or "-" is specified, then it will be
+    /// read from standard input as a hex string. If none are passed, random
+    /// ones will be generated if the ciphersuite is redpallas. If one or
+    /// more are passed, the number should match the `message` parameter.
+    #[arg(short = 'r', long)]
+    pub randomizer: Vec<String>,
+    /// Where to write the generated raw bytes signature. If "-", the
+    /// human-readable hex-string is printed to stdout.
+    #[arg(short = 'o', long, default_value = "")]
+    pub signature: String,
+}
+
+pub async fn run(args: &Command) -> Result<Vec<u8>, Box<dyn Error>> {
+    let Command::Coordinator(CoordinatorCommand { config, group, .. }) = (*args).clone() else {
         panic!("invalid Command");
     };
 
@@ -28,27 +67,33 @@ pub async fn run(args: &Command) -> Result<(), Box<dyn Error>> {
 
     let group = config.group.get(&group).ok_or_eyre("Group not found")?;
 
-    if group.ciphersuite == Ed25519Sha512::ID {
-        run_for_ciphersuite::<Ed25519Sha512>(args).await
+    let signature = if group.ciphersuite == Ed25519Sha512::ID {
+        run_for_ciphersuite::<Ed25519Sha512>(args)
+            .await?
+            .serialize()?
     } else if group.ciphersuite == PallasBlake2b512::ID {
-        run_for_ciphersuite::<PallasBlake2b512>(args).await
+        run_for_ciphersuite::<PallasBlake2b512>(args)
+            .await?
+            .serialize()?
     } else {
-        Err(eyre!("unsupported ciphersuite").into())
-    }
+        return Err(eyre!("unsupported ciphersuite").into());
+    };
+
+    Ok(signature)
 }
 
 pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
     args: &Command,
-) -> Result<(), Box<dyn Error>> {
-    let Command::Coordinator {
+) -> Result<Signature<C>, Box<dyn Error>> {
+    let Command::Coordinator(CoordinatorCommand {
         config,
         server_url,
         group,
         signers,
         message,
         randomizer,
-        signature,
-    } = (*args).clone()
+        signature: signature_fn,
+    }) = (*args).clone()
     else {
         panic!("invalid Command");
     };
@@ -81,14 +126,14 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
     let num_signers = signers.len() as u16;
 
     let pargs = args::ProcessedArgs {
-        cli: false,
-        http: true,
-        signers,
         num_signers,
         public_key_package,
         messages: args::read_messages(&message, &mut output, &mut input)?,
         randomizers: args::read_randomizers(&randomizer, &mut output, &mut input)?,
-        signature,
+    };
+
+    let args = crate::coordinator::comms::http::Args {
+        signers,
         ip: server_url_parsed
             .host_str()
             .ok_or_eyre("host missing in URL")?
@@ -113,7 +158,12 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
         ),
     };
 
-    cli::cli_for_processed_args(pargs, &mut input, &mut output).await?;
+    let mut comms = HTTPComms::new(&pargs, &args)?;
 
-    Ok(())
+    let signature = cli::coordinator(&mut comms, pargs).await?;
+
+    let serialized_signature = signature.serialize()?;
+    fs::write(&signature_fn, &serialized_signature)?;
+    eprintln!("Raw signature written to {}", &signature_fn);
+    Ok(signature)
 }

--- a/frost-client/src/coordinator/args.rs
+++ b/frost-client/src/coordinator/args.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     env,
     error::Error,
     fs,
@@ -9,8 +8,7 @@ use std::{
 use clap::Parser;
 use eyre::eyre;
 
-use crate::cipher::{PrivateKey, PublicKey};
-use frost_core::{keys::PublicKeyPackage, Ciphersuite, Identifier};
+use frost_core::{keys::PublicKeyPackage, Ciphersuite};
 use frost_rerandomized::Randomizer;
 
 use super::input::read_from_file_or_stdin;
@@ -77,18 +75,6 @@ pub struct Args {
 
 #[derive(Clone)]
 pub struct ProcessedArgs<C: Ciphersuite> {
-    /// CLI mode. If enabled, it will prompt for inputs from stdin
-    /// and print values to stdout, ignoring other flags.
-    /// If false, socket communication is enabled.
-    pub cli: bool,
-
-    /// HTTP mode. If enabled, it will use HTTP communication with a
-    /// FROST server.
-    pub http: bool,
-
-    /// Signers to use in HTTP mode, as a map of public keys to identifiers.
-    pub signers: HashMap<PublicKey, Identifier<C>>,
-
     /// The number of participants.
     pub num_signers: u16,
 
@@ -100,24 +86,6 @@ pub struct ProcessedArgs<C: Ciphersuite> {
 
     /// The randomizers to use.
     pub randomizers: Vec<Randomizer<C>>,
-
-    /// Where to write the generated raw bytes signature. If "-", the
-    /// human-readable hex-string is printed to stdout.
-    pub signature: String,
-
-    /// IP to bind to, if using socket comms.
-    /// IP to connect to, if using HTTP mode.
-    pub ip: String,
-
-    /// Port to bind to, if using socket comms.
-    /// Port to connect to, if using HTTP mode.
-    pub port: u16,
-
-    /// The coordinator's communication private key for HTTP mode.
-    pub comm_privkey: Option<PrivateKey>,
-
-    /// The coordinator's communication public key for HTTP mode.
-    pub comm_pubkey: Option<PublicKey>,
 }
 
 impl<C: Ciphersuite + 'static> ProcessedArgs<C> {
@@ -156,18 +124,10 @@ impl<C: Ciphersuite + 'static> ProcessedArgs<C> {
         let randomizers = read_randomizers(&args.randomizer, output, input)?;
 
         Ok(ProcessedArgs {
-            cli: args.cli,
-            http: false,
-            signers: HashMap::new(),
             num_signers,
             public_key_package,
             messages,
             randomizers,
-            signature: args.signature.clone(),
-            ip: args.ip.clone(),
-            port: args.port,
-            comm_privkey: None,
-            comm_pubkey: None,
         })
     }
 }

--- a/frost-client/src/coordinator/cli.rs
+++ b/frost-client/src/coordinator/cli.rs
@@ -2,14 +2,12 @@ use std::collections::BTreeMap;
 use std::io::{BufRead, Write};
 
 use frost::{round1::SigningCommitments, Identifier, SigningPackage};
-use frost_core::{self as frost, Ciphersuite};
+use frost_core::{self as frost, Ciphersuite, Signature};
 use frost_rerandomized::RandomizedCiphersuite;
 
 use super::args::Args;
 use super::args::ProcessedArgs;
 use super::comms::cli::CLIComms;
-use super::comms::http::HTTPComms;
-use super::comms::socket::SocketComms;
 use super::comms::Comms;
 use super::round_1::get_commitments;
 use super::round_2::send_signing_package_and_get_signature_shares;
@@ -18,75 +16,48 @@ pub async fn cli<C: RandomizedCiphersuite + 'static>(
     args: &Args,
     reader: &mut impl BufRead,
     logger: &mut impl Write,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<Signature<C>, Box<dyn std::error::Error>> {
     let pargs = ProcessedArgs::<C>::new(args, reader, logger)?;
-    cli_for_processed_args(pargs, reader, logger).await
+    let mut comms = CLIComms::new(reader, logger);
+    coordinator(&mut comms, pargs).await
 }
 
-pub async fn cli_for_processed_args<C: RandomizedCiphersuite + 'static>(
+pub async fn coordinator<C: RandomizedCiphersuite + 'static>(
+    comms: &mut dyn Comms<C>,
     pargs: ProcessedArgs<C>,
-    reader: &mut impl BufRead,
-    logger: &mut impl Write,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let mut comms: Box<dyn Comms<C>> = if pargs.cli {
-        Box::new(CLIComms::new())
-    } else if pargs.http {
-        Box::new(HTTPComms::new(&pargs)?)
-    } else {
-        Box::new(SocketComms::new(&pargs))
-    };
-
+) -> Result<Signature<C>, Box<dyn std::error::Error>> {
     if !pargs.randomizers.is_empty() && pargs.randomizers.len() != pargs.messages.len() {
         return Err("Number of randomizers must match number of messages".into());
     }
 
-    let r = get_commitments(&pargs, &mut *comms, reader, logger).await;
+    let r = get_commitments(&pargs, &mut *comms).await;
     let Ok(participants_config) = r else {
         let _ = comms.cleanup_on_error().await;
         return Err(r.unwrap_err());
     };
 
-    let signing_package =
-        build_signing_package(&pargs, logger, participants_config.commitments.clone());
+    let signing_package = build_signing_package(&pargs, participants_config.commitments.clone());
 
     let r = send_signing_package_and_get_signature_shares(
         &pargs,
         &mut *comms,
-        reader,
-        logger,
         participants_config,
         &signing_package,
     )
     .await;
 
-    if let Err(e) = r {
-        let _ = comms.cleanup_on_error().await;
-        return Err(e);
+    match r {
+        Ok(signature) => Ok(signature),
+        Err(e) => {
+            let _ = comms.cleanup_on_error().await;
+            Err(e)
+        }
     }
-
-    Ok(())
 }
 
 pub fn build_signing_package<C: Ciphersuite>(
     args: &ProcessedArgs<C>,
-    logger: &mut dyn Write,
     commitments: BTreeMap<Identifier<C>, SigningCommitments<C>>,
 ) -> SigningPackage<C> {
-    let signing_package = SigningPackage::new(commitments, &args.messages[0]);
-    if args.cli {
-        print_signing_package(logger, &signing_package);
-    }
-    signing_package
-}
-
-fn print_signing_package<C: Ciphersuite>(
-    logger: &mut dyn Write,
-    signing_package: &SigningPackage<C>,
-) {
-    writeln!(
-        logger,
-        "Signing Package:\n{}",
-        serde_json::to_string(&signing_package).unwrap()
-    )
-    .unwrap();
+    SigningPackage::new(commitments, &args.messages[0])
 }

--- a/frost-client/src/coordinator/comms.rs
+++ b/frost-client/src/coordinator/comms.rs
@@ -2,13 +2,9 @@ pub mod cli;
 pub mod http;
 pub mod socket;
 
-use frost_core::{self as frost, Ciphersuite};
+use frost_core::{self as frost, Ciphersuite, Signature};
 
-use std::{
-    collections::BTreeMap,
-    error::Error,
-    io::{BufRead, Write},
-};
+use std::{collections::BTreeMap, error::Error};
 
 use async_trait::async_trait;
 
@@ -40,19 +36,17 @@ pub enum Message<C: Ciphersuite> {
 pub trait Comms<C: Ciphersuite> {
     async fn get_signing_commitments(
         &mut self,
-        input: &mut dyn BufRead,
-        output: &mut dyn Write,
         pub_key_package: &PublicKeyPackage<C>,
         num_of_participants: u16,
     ) -> Result<BTreeMap<Identifier<C>, SigningCommitments<C>>, Box<dyn Error>>;
 
     async fn send_signing_package_and_get_signature_shares(
         &mut self,
-        input: &mut dyn BufRead,
-        output: &mut dyn Write,
         signing_package: &SigningPackage<C>,
         randomizer: Option<frost_rerandomized::Randomizer<C>>,
     ) -> Result<BTreeMap<Identifier<C>, SignatureShare<C>>, Box<dyn Error>>;
+
+    async fn process_signature(&mut self, signature: &Signature<C>) -> Result<(), Box<dyn Error>>;
 
     /// Do any cleanups in case an error occurs during the protocol run.
     async fn cleanup_on_error(&mut self) -> Result<(), Box<dyn Error>> {

--- a/frost-client/src/coordinator/comms/cli.rs
+++ b/frost-client/src/coordinator/comms/cli.rs
@@ -1,6 +1,6 @@
 //! Command line interface implementation of the Comms trait.
 
-use frost_core as frost;
+use frost_core::{self as frost, Signature};
 
 use frost_core::Ciphersuite;
 
@@ -20,31 +20,67 @@ use std::{
 
 use super::Comms;
 
-#[derive(Default)]
-pub struct CLIComms<C: Ciphersuite> {
+pub fn print_participants<C: Ciphersuite>(
+    logger: &mut dyn Write,
+    participants: &BTreeMap<Identifier<C>, SigningCommitments<C>>,
+) {
+    writeln!(logger, "Selected participants: ",).unwrap();
+
+    for p in participants.keys() {
+        writeln!(logger, "{}", serde_json::to_string(p).unwrap()).unwrap();
+    }
+}
+
+fn print_signing_package<C: Ciphersuite>(
+    logger: &mut dyn Write,
+    signing_package: &SigningPackage<C>,
+) {
+    writeln!(
+        logger,
+        "Signing Package:\n{}",
+        serde_json::to_string(&signing_package).unwrap()
+    )
+    .unwrap();
+}
+
+fn print_signature<C: Ciphersuite + 'static>(
+    logger: &mut dyn Write,
+    group_signature: Signature<C>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    writeln!(
+        logger,
+        "Signature:\n{}",
+        hex::encode(&group_signature.serialize()?)
+    )?;
+    Ok(())
+}
+
+pub struct CLIComms<'a, C: Ciphersuite> {
+    reader: &'a mut dyn BufRead,
+    writer: &'a mut dyn Write,
     _phantom: PhantomData<C>,
 }
 
-impl<C> CLIComms<C>
+impl<'a, C> CLIComms<'a, C>
 where
     C: Ciphersuite,
 {
-    pub fn new() -> Self {
+    pub fn new(reader: &'a mut dyn BufRead, writer: &'a mut dyn Write) -> Self {
         Self {
+            reader,
+            writer,
             _phantom: Default::default(),
         }
     }
 }
 
 #[async_trait(?Send)]
-impl<C> Comms<C> for CLIComms<C>
+impl<'a, C> Comms<C> for CLIComms<'a, C>
 where
     C: Ciphersuite + 'static,
 {
     async fn get_signing_commitments(
         &mut self,
-        input: &mut dyn BufRead,
-        output: &mut dyn Write,
         pub_key_package: &PublicKeyPackage<C>,
         num_of_participants: u16,
     ) -> Result<BTreeMap<Identifier<C>, SigningCommitments<C>>, Box<dyn Error>> {
@@ -52,49 +88,58 @@ where
         let mut commitments_list: BTreeMap<Identifier<C>, SigningCommitments<C>> = BTreeMap::new();
 
         for i in 1..=num_of_participants {
-            writeln!(output, "Identifier for participant {i:?} (hex encoded): ")?;
-            let id_value = read_identifier(input)?;
+            writeln!(
+                self.writer,
+                "Identifier for participant {i:?} (hex encoded): "
+            )?;
+            let id_value = read_identifier(self.reader)?;
             validate(id_value, pub_key_package, &participants_list)?;
             participants_list.push(id_value);
 
             writeln!(
-                output,
+                self.writer,
                 "Please enter JSON encoded commitments for participant {}:",
                 hex::encode(id_value.serialize())
             )?;
             let mut commitments_input = String::new();
-            input.read_line(&mut commitments_input)?;
+            self.reader.read_line(&mut commitments_input)?;
             let commitments = serde_json::from_str(&commitments_input)?;
             commitments_list.insert(id_value, commitments);
         }
+
+        print_participants(self.writer, &commitments_list);
 
         Ok(commitments_list)
     }
 
     async fn send_signing_package_and_get_signature_shares(
         &mut self,
-        input: &mut dyn BufRead,
-        output: &mut dyn Write,
         signing_package: &SigningPackage<C>,
         randomizer: Option<frost_rerandomized::Randomizer<C>>,
     ) -> Result<BTreeMap<Identifier<C>, SignatureShare<C>>, Box<dyn Error>> {
+        print_signing_package(self.writer, signing_package);
         if randomizer.is_some() {
             panic!("rerandomized not supported");
         }
         let mut signatures_list: BTreeMap<Identifier<C>, SignatureShare<C>> = BTreeMap::new();
         for p in signing_package.signing_commitments().keys() {
             writeln!(
-                output,
+                self.writer,
                 "Please enter JSON encoded signature shares for participant {}:",
                 hex::encode(p.serialize())
             )?;
 
             let mut signature_input = String::new();
-            input.read_line(&mut signature_input)?;
+            self.reader.read_line(&mut signature_input)?;
             let signatures = serde_json::from_str(&signature_input)?;
             signatures_list.insert(*p, signatures);
         }
         Ok(signatures_list)
+    }
+
+    async fn process_signature(&mut self, signature: &Signature<C>) -> Result<(), Box<dyn Error>> {
+        print_signature(self.writer, *signature)?;
+        Ok(())
     }
 }
 

--- a/frost-client/src/coordinator/comms/http.rs
+++ b/frost-client/src/coordinator/comms/http.rs
@@ -3,7 +3,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
     error::Error,
-    io::{BufRead, Write},
     marker::PhantomData,
     time::Duration,
     vec,
@@ -13,11 +12,11 @@ use async_trait::async_trait;
 use eyre::{eyre, OptionExt};
 use frost_core::{
     keys::PublicKeyPackage, round1::SigningCommitments, round2::SignatureShare, Ciphersuite,
-    Identifier, SigningPackage,
+    Identifier, Signature, SigningPackage,
 };
 use rand::thread_rng;
 
-use crate::cipher::Cipher;
+use crate::cipher::{Cipher, PrivateKey};
 use crate::client::Client;
 use crate::{
     api::{self, PublicKey, SendSigningPackageArgs, Uuid},
@@ -27,10 +26,30 @@ use crate::{
 use super::super::args::ProcessedArgs;
 use super::Comms;
 
+#[derive(Clone)]
+pub struct Args<C: Ciphersuite> {
+    /// Signers to use in HTTP mode, as a map of public keys to identifiers.
+    pub signers: HashMap<PublicKey, Identifier<C>>,
+
+    /// IP to bind to, if using socket comms.
+    /// IP to connect to, if using HTTP mode.
+    pub ip: String,
+
+    /// Port to bind to, if using socket comms.
+    /// Port to connect to, if using HTTP mode.
+    pub port: u16,
+
+    /// The coordinator's communication private key for HTTP mode.
+    pub comm_privkey: Option<PrivateKey>,
+
+    /// The coordinator's communication public key for HTTP mode.
+    pub comm_pubkey: Option<PublicKey>,
+}
+
 pub struct HTTPComms<C: Ciphersuite> {
     client: Client,
     session_id: Option<Uuid>,
-    args: ProcessedArgs<C>,
+    args: Args<C>,
     state: CoordinatorSessionState<C>,
     pubkeys: HashMap<PublicKey, Identifier<C>>,
     cipher: Option<Cipher>,
@@ -38,14 +57,14 @@ pub struct HTTPComms<C: Ciphersuite> {
 }
 
 impl<C: Ciphersuite> HTTPComms<C> {
-    pub fn new(args: &ProcessedArgs<C>) -> Result<Self, Box<dyn Error>> {
+    pub fn new(pargs: &ProcessedArgs<C>, args: &Args<C>) -> Result<Self, Box<dyn Error>> {
         Ok(Self {
             client: Client::new(format!("https://{}:{}", args.ip, args.port)),
             session_id: None,
             args: args.clone(),
             state: CoordinatorSessionState::new(
-                args.messages.len(),
-                args.num_signers as usize,
+                pargs.messages.len(),
+                pargs.num_signers as usize,
                 args.signers.clone(),
             ),
             pubkeys: Default::default(),
@@ -59,8 +78,6 @@ impl<C: Ciphersuite> HTTPComms<C> {
 impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
     async fn get_signing_commitments(
         &mut self,
-        _input: &mut dyn BufRead,
-        _output: &mut dyn Write,
         _pub_key_package: &PublicKeyPackage<C>,
         _num_signers: u16,
     ) -> Result<BTreeMap<Identifier<C>, SigningCommitments<C>>, Box<dyn Error>> {
@@ -149,8 +166,6 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
 
     async fn send_signing_package_and_get_signature_shares(
         &mut self,
-        _input: &mut dyn BufRead,
-        _output: &mut dyn Write,
         signing_package: &SigningPackage<C>,
         randomizer: Option<frost_rerandomized::Randomizer<C>>,
     ) -> Result<BTreeMap<Identifier<C>, SignatureShare<C>>, Box<dyn Error>> {
@@ -218,6 +233,10 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
 
         // TODO: support more than 1
         Ok(signature_shares[0].clone())
+    }
+
+    async fn process_signature(&mut self, _signature: &Signature<C>) -> Result<(), Box<dyn Error>> {
+        Ok(())
     }
 
     async fn cleanup_on_error(&mut self) -> Result<(), Box<dyn Error>> {

--- a/frost-client/src/coordinator/comms/socket.rs
+++ b/frost-client/src/coordinator/comms/socket.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 
-use frost_core as frost;
+use frost_core::{self as frost, Signature};
 
 use frost_core::Ciphersuite;
 
@@ -18,14 +18,8 @@ use frost::{
     SigningPackage,
 };
 
-use std::{
-    collections::BTreeMap,
-    error::Error,
-    io::{BufRead, Write},
-    marker::PhantomData,
-};
+use std::{collections::BTreeMap, error::Error, marker::PhantomData};
 
-use super::super::args::ProcessedArgs;
 use super::{Comms, Message};
 
 pub struct SocketComms<C: Ciphersuite> {
@@ -36,9 +30,9 @@ pub struct SocketComms<C: Ciphersuite> {
 }
 
 impl<C: Ciphersuite> SocketComms<C> {
-    pub fn new(args: &ProcessedArgs<C>) -> Self {
+    pub fn new(ip: String, port: String) -> Self {
         let (handler, listener) = node::split::<()>();
-        let addr = format!("{}:{}", args.ip, args.port);
+        let addr = format!("{}:{}", ip, port);
         let (tx, rx) = mpsc::channel(2000);
 
         let _ = handler
@@ -77,8 +71,6 @@ impl<C: Ciphersuite> SocketComms<C> {
 impl<C: Ciphersuite> Comms<C> for SocketComms<C> {
     async fn get_signing_commitments(
         &mut self,
-        _input: &mut dyn BufRead,
-        _output: &mut dyn Write,
         _pub_key_package: &PublicKeyPackage<C>,
         num_of_participants: u16,
     ) -> Result<BTreeMap<Identifier<C>, SigningCommitments<C>>, Box<dyn Error>> {
@@ -108,8 +100,6 @@ impl<C: Ciphersuite> Comms<C> for SocketComms<C> {
 
     async fn send_signing_package_and_get_signature_shares(
         &mut self,
-        _input: &mut dyn BufRead,
-        _output: &mut dyn Write,
         signing_package: &SigningPackage<C>,
         randomizer: Option<frost_rerandomized::Randomizer<C>>,
     ) -> Result<BTreeMap<Identifier<C>, SignatureShare<C>>, Box<dyn Error>> {
@@ -151,5 +141,9 @@ impl<C: Ciphersuite> Comms<C> for SocketComms<C> {
             }
         }
         Ok(signature_shares)
+    }
+
+    async fn process_signature(&mut self, _signature: &Signature<C>) -> Result<(), Box<dyn Error>> {
+        Ok(())
     }
 }

--- a/frost-client/src/coordinator/main.rs
+++ b/frost-client/src/coordinator/main.rs
@@ -11,9 +11,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut reader = Box::new(io::stdin().lock());
     let mut logger = io::stdout();
     let r = if args.ciphersuite == "ed25519" {
-        cli::<frost_ed25519::Ed25519Sha512>(&args, &mut reader, &mut logger).await
+        cli::<frost_ed25519::Ed25519Sha512>(&args, &mut reader, &mut logger)
+            .await
+            .map(|_| ())
     } else if args.ciphersuite == "redpallas" {
-        cli::<reddsa::frost::redpallas::PallasBlake2b512>(&args, &mut reader, &mut logger).await
+        cli::<reddsa::frost::redpallas::PallasBlake2b512>(&args, &mut reader, &mut logger)
+            .await
+            .map(|_| ())
     } else {
         panic!("invalid ciphersuite");
     };

--- a/frost-client/src/coordinator/round_1.rs
+++ b/frost-client/src/coordinator/round_1.rs
@@ -2,10 +2,7 @@ use frost_core::{self as frost, Ciphersuite};
 
 use frost::{keys::PublicKeyPackage, round1::SigningCommitments, Identifier};
 
-use std::{
-    collections::BTreeMap,
-    io::{BufRead, Write},
-};
+use std::collections::BTreeMap;
 
 use super::{args::ProcessedArgs, comms::Comms};
 
@@ -18,13 +15,8 @@ pub struct ParticipantsConfig<C: Ciphersuite> {
 pub async fn get_commitments<C: Ciphersuite>(
     args: &ProcessedArgs<C>,
     comms: &mut dyn Comms<C>,
-    reader: &mut dyn BufRead,
-    logger: &mut dyn Write,
 ) -> Result<ParticipantsConfig<C>, Box<dyn std::error::Error>> {
-    let participants = read_commitments(args, comms, reader, logger).await?;
-    if args.cli {
-        print_participants(logger, &participants.commitments);
-    }
+    let participants = read_commitments(args, comms).await?;
     Ok(participants)
 }
 
@@ -37,28 +29,15 @@ pub async fn get_commitments<C: Ciphersuite>(
 async fn read_commitments<C: Ciphersuite>(
     args: &ProcessedArgs<C>,
     comms: &mut dyn Comms<C>,
-    input: &mut dyn BufRead,
-    logger: &mut dyn Write,
 ) -> Result<ParticipantsConfig<C>, Box<dyn std::error::Error>> {
     let commitments_list = comms
-        .get_signing_commitments(input, logger, &args.public_key_package, args.num_signers)
+        .get_signing_commitments(&args.public_key_package, args.num_signers)
         .await?;
 
     Ok(ParticipantsConfig {
         commitments: commitments_list,
         pub_key_package: args.public_key_package.clone(),
     })
-}
-
-pub fn print_participants<C: Ciphersuite>(
-    logger: &mut dyn Write,
-    participants: &BTreeMap<Identifier<C>, SigningCommitments<C>>,
-) {
-    writeln!(logger, "Selected participants: ",).unwrap();
-
-    for p in participants.keys() {
-        writeln!(logger, "{}", serde_json::to_string(p).unwrap()).unwrap();
-    }
 }
 
 #[cfg(test)]

--- a/frost-client/src/coordinator/round_2.rs
+++ b/frost-client/src/coordinator/round_2.rs
@@ -5,25 +5,16 @@ use frost_rerandomized::{RandomizedCiphersuite, Randomizer};
 use rand::thread_rng;
 use reddsa::frost::redpallas::PallasBlake2b512;
 
-use std::{
-    fs,
-    io::{BufRead, Write},
-};
-
 use super::{args::ProcessedArgs, comms::Comms, round_1::ParticipantsConfig};
 
 pub async fn send_signing_package_and_get_signature_shares<C: RandomizedCiphersuite + 'static>(
     args: &ProcessedArgs<C>,
     comms: &mut dyn Comms<C>,
-    input: &mut dyn BufRead,
-    logger: &mut dyn Write,
     participants: ParticipantsConfig<C>,
     signing_package: &SigningPackage<C>,
 ) -> Result<Signature<C>, Box<dyn std::error::Error>> {
     let group_signature =
-        request_inputs_signature_shares(args, comms, input, logger, participants, signing_package)
-            .await?;
-    print_signature(args, logger, group_signature)?;
+        request_inputs_signature_shares(args, comms, participants, signing_package).await?;
     Ok(group_signature)
 }
 
@@ -33,8 +24,6 @@ pub async fn send_signing_package_and_get_signature_shares<C: RandomizedCiphersu
 async fn request_inputs_signature_shares<C: RandomizedCiphersuite + 'static>(
     args: &ProcessedArgs<C>,
     comms: &mut dyn Comms<C>,
-    input: &mut dyn BufRead,
-    logger: &mut dyn Write,
     participants: ParticipantsConfig<C>,
     signing_package: &SigningPackage<C>,
 ) -> Result<Signature<C>, Box<dyn std::error::Error>> {
@@ -49,7 +38,7 @@ async fn request_inputs_signature_shares<C: RandomizedCiphersuite + 'static>(
     };
 
     let signatures_list = comms
-        .send_signing_package_and_get_signature_shares(input, logger, signing_package, randomizer)
+        .send_signing_package_and_get_signature_shares(signing_package, randomizer)
         .await?;
 
     let group_signature = if let Some(randomizer) = randomizer {
@@ -74,23 +63,7 @@ async fn request_inputs_signature_shares<C: RandomizedCiphersuite + 'static>(
         .unwrap()
     };
 
-    Ok(group_signature)
-}
+    comms.process_signature(&group_signature).await?;
 
-fn print_signature<C: Ciphersuite + 'static>(
-    args: &ProcessedArgs<C>,
-    logger: &mut dyn Write,
-    group_signature: Signature<C>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if args.signature.is_empty() {
-        writeln!(
-            logger,
-            "Signature:\n{}",
-            hex::encode(&group_signature.serialize()?)
-        )?;
-    } else {
-        fs::write(&args.signature, group_signature.serialize()?)?;
-        eprintln!("Raw signature written to {}", &args.signature);
-    };
-    Ok(())
+    Ok(group_signature)
 }

--- a/frost-client/src/coordinator/tests/common/mod.rs
+++ b/frost-client/src/coordinator/tests/common/mod.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
+#![allow(unused)]
 
 pub struct Helpers {
     pub participant_id_1: String,

--- a/frost-client/src/coordinator/tests/steps.rs
+++ b/frost-client/src/coordinator/tests/steps.rs
@@ -2,7 +2,6 @@
 
 use crate::coordinator::{
     args::{Args, ProcessedArgs},
-    cli::build_signing_package,
     comms::cli::CLIComms,
     round_1::{get_commitments, ParticipantsConfig},
     round_2::send_signing_package_and_get_signature_shares,
@@ -13,7 +12,10 @@ use frost::{
     Identifier, SigningPackage, VerifyingKey,
 };
 use frost_ed25519 as frost;
-use std::{collections::BTreeMap, io::BufWriter};
+use std::{
+    collections::BTreeMap,
+    io::{BufWriter, Cursor, Write},
+};
 
 use super::common::get_helpers;
 use super::common::Helpers;
@@ -95,7 +97,6 @@ async fn check_step_1() {
         ..
     } = get_helpers();
 
-    let mut comms = CLIComms::new();
     let args = Args::default();
     let mut buf = BufWriter::new(Vec::new());
 
@@ -109,10 +110,11 @@ async fn check_step_1() {
 
     let pargs = ProcessedArgs::new(&args, &mut input.as_bytes(), &mut buf).unwrap();
 
-    let input = format!(
+    let mut input = Cursor::new(format!(
         "{participant_id_1}\n{commitments_input_1}\n{participant_id_3}\n{commitments_input_3}\n"
-    );
+    ));
     let mut buf = BufWriter::new(Vec::new());
+    let mut comms = CLIComms::new(&mut input, &mut buf);
 
     let (signer_pub_keys, group_public) = build_pub_key_package();
 
@@ -121,55 +123,9 @@ async fn check_step_1() {
         pub_key_package: PublicKeyPackage::new(signer_pub_keys, group_public),
     };
 
-    let participants_config =
-        get_commitments(&pargs, &mut comms, &mut input.as_bytes(), &mut buf).await;
+    let participants_config = get_commitments(&pargs, &mut comms).await;
 
     assert!(participants_config.unwrap() == expected_participants_config);
-}
-
-// Input required:
-// 1. message
-// 2. number of signers
-// 3. commitments for all signers
-#[tokio::test]
-async fn check_step_2() {
-    let Helpers {
-        commitments_from_part_1,
-        commitments_from_part_3,
-        signing_package_helper,
-        message,
-        pub_key_package,
-        ..
-    } = get_helpers();
-
-    let args = Args {
-        cli: true,
-        ..Default::default()
-    };
-    let mut buf = BufWriter::new(Vec::new());
-
-    let input = format!(
-        "2\n{pub_key_package}\n{message}\n{commitments_from_part_1}\n{commitments_from_part_3}\n"
-    );
-    let pargs = ProcessedArgs::new(&args, &mut input.as_bytes(), &mut buf).unwrap();
-
-    let signing_commitments = build_signing_commitments();
-
-    let message = hex::decode(message).unwrap();
-
-    let expected_signing_package = SigningPackage::new(signing_commitments.clone(), &message);
-
-    let mut buf = BufWriter::new(Vec::new());
-    let signing_package = build_signing_package(&pargs, &mut buf, signing_commitments.clone());
-
-    assert!(signing_package == expected_signing_package);
-
-    let expected = format!("Signing Package:\n{signing_package_helper}\n");
-
-    let (_, res) = &buf.into_parts();
-    let actual = String::from_utf8(res.as_ref().unwrap().to_owned()).unwrap();
-
-    assert_eq!(expected, actual)
 }
 
 // // Input required:
@@ -188,7 +144,6 @@ async fn check_step_3() {
         ..
     } = get_helpers();
 
-    let mut comms = CLIComms::new();
     let mut buf = BufWriter::new(Vec::new());
     let args = Args::default();
 
@@ -217,23 +172,22 @@ async fn check_step_3() {
     let signing_package = SigningPackage::new(commitments, &message);
 
     // step 3 generate signature
-
     let mut buf = BufWriter::new(Vec::new());
+    let mut comms = CLIComms::new(&mut valid_input, &mut buf);
+
     send_signing_package_and_get_signature_shares(
         &pargs,
         &mut comms,
-        &mut valid_input,
-        &mut buf,
         participants_config,
         &signing_package,
     )
     .await
     .unwrap();
 
-    let expected = format!("Please enter JSON encoded signature shares for participant {participant_id_1}:\nPlease enter JSON encoded signature shares for participant {participant_id_3}:\nSignature:\n{group_signature}\n");
+    let expected = format!("Signing Package:\n{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"signing_commitments\":{{\"0100000000000000000000000000000000000000000000000000000000000000\":{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"hiding\":\"4a413c35349ebb5cc2b931270c5886df98b6e1e621bd364648b99e3cf7f02bbf\",\"binding\":\"fa99e65abd54bf22a005109591a1a8cf060cdb80155a408b005c5187697d8a4b\"}},\"0300000000000000000000000000000000000000000000000000000000000000\":{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"hiding\":\"50de72191c1d6473954113df25bd05fa4915c01813a70cf1e93db5f75e49e949\",\"binding\":\"ddec2b43bc985d653229ce7bfa829a157c33baad284e2c35eafd8c3886d18a8b\"}}}},\"message\":\"74657374\"}}\nPlease enter JSON encoded signature shares for participant {participant_id_1}:\nPlease enter JSON encoded signature shares for participant {participant_id_3}:\nSignature:\n{group_signature}\n");
 
-    let (_, res) = &buf.into_parts();
-    let actual = String::from_utf8(res.as_ref().unwrap().to_owned()).unwrap();
+    buf.flush().unwrap();
+    let actual = String::from_utf8(buf.into_inner().unwrap()).unwrap();
 
     assert_eq!(expected, actual)
 }

--- a/frost-client/src/lib.rs
+++ b/frost-client/src/lib.rs
@@ -7,3 +7,5 @@ pub mod dkg;
 pub mod participant;
 pub mod session;
 pub mod trusted_dealer;
+
+pub use reddsa;

--- a/frost-client/src/main.rs
+++ b/frost-client/src/main.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Command::Sessions { .. } => cli::session::list(&args.command).await,
         Command::TrustedDealer { .. } => cli::trusted_dealer::trusted_dealer(&args.command),
         Command::Dkg { .. } => cli::dkg::dkg(&args.command).await,
-        Command::Coordinator { .. } => cli::coordinator::run(&args.command).await,
+        Command::Coordinator { .. } => cli::coordinator::run(&args.command).await.map(|_| ()),
         Command::Participant { .. } => cli::participant::run(&args.command).await,
     }?;
 

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -13,6 +13,7 @@ use frost::Identifier;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::io::BufWriter;
+use std::io::Cursor;
 use std::vec;
 
 use rand::thread_rng;
@@ -37,7 +38,6 @@ async fn trusted_dealer_journey() {
         message: vec![],
         ..Default::default()
     };
-    let mut coordinator_comms = CoordinatorCLIComms::new();
 
     // For a CLI test we can use the same CLIComms instance
     let mut participant_comms = ParticipantCLIComms::new();
@@ -119,7 +119,7 @@ async fn trusted_dealer_journey() {
     let pcoordinator_args =
         ProcessedArgs::new(&coordinator_args, &mut input.as_bytes(), &mut buf).unwrap();
 
-    let step_1_input = format!(
+    let mut input = Cursor::new(format!(
         "{}\n{}\n{}\n{}\n{}\n{}\n",
         id_input_1,
         serde_json::to_string(&commitments_map[&participant_id_1]).unwrap(),
@@ -127,13 +127,13 @@ async fn trusted_dealer_journey() {
         serde_json::to_string(&commitments_map[&participant_id_2]).unwrap(),
         id_input_3,
         serde_json::to_string(&commitments_map[&participant_id_3]).unwrap(),
-    );
+    ));
+
+    let mut coordinator_comms = CoordinatorCLIComms::new(&mut input, &mut buf);
 
     let participants_config = frost_client::coordinator::round_1::get_commitments(
         &pcoordinator_args,
         &mut coordinator_comms,
-        &mut step_1_input.as_bytes(),
-        &mut buf,
     )
     .await
     .unwrap();
@@ -144,11 +144,11 @@ async fn trusted_dealer_journey() {
 
     let signing_package = frost_client::coordinator::cli::build_signing_package(
         &pcoordinator_args,
-        &mut buf,
         commitments_map.clone(),
     );
 
     // Round 2
+    let mut buf = BufWriter::new(Vec::new());
 
     for participant_index in 1..=3 {
         let participant_identifier = Identifier::try_from(participant_index).unwrap();
@@ -175,18 +175,19 @@ async fn trusted_dealer_journey() {
 
     // coordinator step 3
 
-    let step_3_input = format!(
+    let mut step_3_input = Cursor::new(format!(
         "{}\n{}\n{}\n",
         serde_json::to_string(&signature_shares[&participant_id_1]).unwrap(),
         serde_json::to_string(&signature_shares[&participant_id_2]).unwrap(),
         serde_json::to_string(&signature_shares[&participant_id_3]).unwrap()
-    );
+    ));
+    // We recreate coordinator_comms to be able to provide new input
+    let mut coordinator_comms = CoordinatorCLIComms::new(&mut step_3_input, &mut buf);
+
     let group_signature =
         frost_client::coordinator::round_2::send_signing_package_and_get_signature_shares(
             &pcoordinator_args,
             &mut coordinator_comms,
-            &mut step_3_input.as_bytes(),
-            &mut buf,
             participants_config,
             &signing_package,
         )


### PR DESCRIPTION
Based on https://github.com/ZcashFoundation/frost-tools/pull/574 which needs to be merge first.

The big change is removing any reference to input/output from the main code and leave it to the `Comms` implementation.

Additionally, the signature is returned instead of being written to a file/printed (this logic has moved to the caller CLI code)

I haven't thoroughly tested if the old CLI workflow is working correctly, but the tests are passing. We might want to revisit the CLI/sockets options to review them or decide if we want to remove them.

There is a lot of stuff to improve still but I don't want to do everything in a single PR.