### PR TITLE
confirm PCZT contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,6 +1300,7 @@ dependencies = [
  "toml",
  "uuid",
  "xeddsa",
+ "zcash-sign",
  "zeroize",
 ]
 
@@ -5001,6 +5002,7 @@ dependencies = [
  "zcash_primitives",
  "zcash_proofs",
  "zcash_protocol",
+ "zcash_script",
  "zcash_transparent",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ zcash_keys = "0.12.0"
 zcash_primitives = "0.26.1"
 zcash_proofs = "0.26.1"
 zcash_protocol = "0.7.1"
+zcash-sign = { path = "zcash-sign" }
 zcash_transparent = "0.6"
 zeroize = "1.8.1"
 

--- a/frost-client/Cargo.toml
+++ b/frost-client/Cargo.toml
@@ -53,3 +53,4 @@ thiserror = { workspace = true }
 zeroize = { workspace = true, features = ["serde", "zeroize_derive"] }
 message-io = { workspace = true }
 uuid = { workspace = true, features = ["v4", "fast-rng", "serde"] }
+zcash-sign = { workspace = true }

--- a/frost-client/src/cli/coordinator.rs
+++ b/frost-client/src/cli/coordinator.rs
@@ -1,10 +1,14 @@
 use std::collections::HashMap;
 use std::error::Error;
-use std::fs;
 
 use eyre::eyre;
 use eyre::Context;
 use eyre::OptionExt;
+use frost_core::Signature;
+use frost_rerandomized::Randomizer;
+use serde::Deserialize;
+use serde::Serialize;
+use zcash_sign::confirm::ParsedPczt;
 
 use crate::cipher::PublicKey;
 use crate::coordinator::comms::http::HTTPComms;
@@ -20,6 +24,12 @@ use crate::coordinator::cli;
 
 use super::args::Command;
 use super::config::Config;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ParsedAuxMsg<'a> {
+    pub content_type: &'a str,
+    pub data: Option<&'a [u8]>,
+}
 
 #[derive(clap::Args, Clone, Debug)]
 pub struct CoordinatorCommand {
@@ -54,6 +64,13 @@ pub struct CoordinatorCommand {
     /// An optional auxiliary message to include in the signing package.
     #[arg(short = 'a', long)]
     pub aux_message: Option<String>,
+    /// The content type of the messages. Defaults to
+    /// "application/octet-stream". If "application/vnd.zcash.pczt" is
+    /// specified, the messages and randomizers must be empty, and the
+    /// `aux_message` argument must contain a PCZT file. The signed PCZT will be
+    /// written to the file specified by the `signature` argument.
+    #[arg(short = 't', long, default_value = "application/octet-stream")]
+    pub content_type: String,
     /// Where to write the generated raw bytes signatures. Each instance can be
     /// a file path where the raw signature will be written, or "-". If "-" is
     /// specified, the human-readable hex-string is printed to stdout.
@@ -84,28 +101,26 @@ pub async fn run(args: &Command) -> Result<(), Box<dyn Error>> {
 pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
     args: &Command,
 ) -> Result<(), Box<dyn Error>> {
-    let Command::Coordinator(CoordinatorCommand {
+    let Command::Coordinator(cmd) = args else {
+        panic!("invalid Command");
+    };
+    let CoordinatorCommand {
         config,
         server_url,
         group,
         signers,
-        message,
-        randomizer,
-        signature: signature_fn,
-        aux_message,
-    }) = (*args).clone()
-    else {
-        panic!("invalid Command");
-    };
+        message: _,
+        randomizer: _,
+        signature: _,
+        aux_message: _,
+        content_type,
+    } = cmd.clone();
 
     let config = Config::read(config)?;
 
     let group = config.group.get(&group).ok_or_eyre("Group not found")?;
 
     let public_key_package: PublicKeyPackage<C> = postcard::from_bytes(&group.public_key_package)?;
-
-    let mut input = Box::new(std::io::stdin().lock());
-    let mut output = std::io::stdout();
 
     let server_url = if let Some(server_url) = server_url {
         server_url
@@ -114,10 +129,6 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
     };
     let server_url_parsed =
         Url::parse(&format!("https://{server_url}")).wrap_err("error parsing server-url")?;
-
-    if message.len() != signature_fn.len() {
-        return Err("Number of messages must match number of signature output files".into());
-    }
 
     let signers = signers
         .iter()
@@ -129,14 +140,15 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
         .collect::<Result<HashMap<_, _>, Box<dyn Error>>>()?;
     let num_signers = signers.len() as u16;
 
+    let signing_inputs = read_signing_inputs::<C>(cmd)?;
+
     let pargs = args::ProcessedArgs {
         num_signers,
         public_key_package,
-        messages: args::read_messages(&message, &mut output, &mut input)?,
-        randomizers: args::read_randomizers(&randomizer, &mut output, &mut input)?,
-        aux_msg: aux_message
-            .map(|filename| args::read_aux_message(&filename, &mut output, &mut input))
-            .transpose()?,
+        messages: signing_inputs.messages.clone(),
+        randomizers: signing_inputs.randomizers.clone(),
+        aux_msg: signing_inputs.aux_msg.clone(),
+        content_type,
     };
 
     let args = crate::coordinator::comms::http::Args {
@@ -169,15 +181,93 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
 
     let signatures = cli::coordinator(&mut comms, pargs).await?;
 
-    for (signature, signature_fn) in signatures.iter().zip(signature_fn.iter()) {
-        if signature_fn == "-" || signature_fn.is_empty() {
-            let hex_signature = hex::encode(signature.serialize()?);
-            eprintln!("{hex_signature}");
-        } else {
-            fs::write(signature_fn, signature.serialize()?)?;
-            eprintln!("Raw signature written to {}", signature_fn);
+    write_signing_outputs(cmd, &signing_inputs, signatures)?;
+
+    Ok(())
+}
+
+struct SigningInputs<C: frost_core::Ciphersuite> {
+    messages: Vec<Vec<u8>>,
+    randomizers: Vec<Randomizer<C>>,
+    aux_msg: Option<Vec<u8>>,
+}
+
+fn read_signing_inputs<C: frost_core::Ciphersuite>(
+    cmd: &CoordinatorCommand,
+) -> Result<SigningInputs<C>, Box<dyn Error>> {
+    let mut input = Box::new(std::io::stdin().lock());
+    let mut output = std::io::stdout();
+
+    if cmd.content_type == "application/octet-stream" {
+        if cmd.message.len() != cmd.signature.len() {
+            return Err("Number of messages must match number of signature output files".into());
+        }
+
+        Ok(SigningInputs {
+            messages: args::read_messages(&cmd.message, &mut output, &mut input)?,
+            randomizers: args::read_randomizers(&cmd.randomizer, &mut output, &mut input)?,
+            aux_msg: cmd
+                .aux_message
+                .as_ref()
+                .map(|filename| args::read_aux_message(filename, &mut output, &mut input))
+                .transpose()?,
+        })
+    } else if cmd.content_type == zcash_sign::PCZT_CONTENT_TYPE {
+        if !cmd.message.is_empty() || !cmd.randomizer.is_empty() {
+            return Err("For PCZT, only the aux_message must be specified with the PCZT; no messages and randomizers must be specified".into());
+        }
+        let filename = cmd
+            .aux_message
+            .as_ref()
+            .ok_or_eyre("aux_message must be specified")?;
+        let pczt_bytes = args::read_aux_message(filename, &mut output, &mut input)?;
+        let pczt = zcash_sign::confirm::ParsedPczt::parse(&pczt_bytes)?;
+        let zcash_sign::SigningInputs { sighash, alphas } =
+            zcash_sign::read_pczt_signining_inputs(&pczt)?;
+        Ok(SigningInputs {
+            // Create a vector with sighash repeated for each alpha
+            messages: vec![sighash; alphas.len()],
+            randomizers: alphas
+                .into_iter()
+                .map(|(_idx, alpha_bytes)| {
+                    let alpha_array: [u8; 32] = alpha_bytes.try_into().unwrap();
+                    Randomizer::<C>::deserialize(&alpha_array).unwrap()
+                })
+                .collect(),
+            aux_msg: Some(pczt_bytes),
+        })
+    } else {
+        Err("content type not supported".into())
+    }
+}
+
+fn write_signing_outputs<C: frost_core::Ciphersuite>(
+    cmd: &CoordinatorCommand,
+    inputs: &SigningInputs<C>,
+    signatures: Vec<Signature<C>>,
+) -> Result<(), Box<dyn Error>> {
+    let signatures = signatures
+        .into_iter()
+        .map(|sig| sig.serialize())
+        .collect::<Result<Vec<_>, frost_core::Error<C>>>()?;
+    match cmd.content_type.as_str() {
+        "application/octet-stream" => {
+            args::write_signatures(&cmd.signature, &signatures)?;
+        }
+        zcash_sign::PCZT_CONTENT_TYPE => {
+            let pczt = ParsedPczt::parse(
+                &inputs
+                    .aux_msg
+                    .clone()
+                    .ok_or_eyre("aux_msg must be specified")?,
+            )?;
+            let signed_pczt_bytes =
+                zcash_sign::write_pczt_signing_outputs(&pczt, &inputs.messages[0], &signatures)?;
+            args::write_signatures(&cmd.signature, &[signed_pczt_bytes])?;
+        }
+        _ => {
+            return Err("content type not supported".into());
         }
     }
-
     Ok(())
 }

--- a/frost-client/src/cli/participant.rs
+++ b/frost-client/src/cli/participant.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::io::stdin;
 use std::rc::Rc;
 
 use eyre::eyre;
@@ -11,12 +12,76 @@ use frost_core::keys::KeyPackage;
 use frost_core::Ciphersuite;
 use frost_ed25519::Ed25519Sha512;
 use frost_rerandomized::RandomizedCiphersuite;
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::{args::Command, config::Config};
 
+use crate::api::SendSigningPackageArgs;
 use crate::participant::args;
 use crate::participant::cli::participant;
 use crate::participant::comms::http::HTTPComms;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ParsedAuxMsg<'a> {
+    pub content_type: &'a str,
+    pub data: Option<&'a [u8]>,
+}
+
+fn parse_aux_msg(aux_msg: &[u8]) -> Result<ParsedAuxMsg<'_>, Box<dyn Error>> {
+    let parsed: ParsedAuxMsg = postcard::from_bytes(aux_msg)?;
+    Ok(parsed)
+}
+
+fn confirm_message<C: Ciphersuite>(args: &SendSigningPackageArgs<C>) -> bool {
+    let aux_msg = match parse_aux_msg(&args.aux_msg) {
+        Err(_) => {
+            eprintln!("Warning: Unable to parse auxiliary message.");
+            return false;
+        }
+        Ok(aux_msg) => aux_msg,
+    };
+    if aux_msg.content_type == zcash_sign::PCZT_CONTENT_TYPE {
+        // For PCZT, all messages are sighashes, and they should all be the same
+        let signed_sighash = args.signing_package[0].message();
+        if args
+            .signing_package
+            .iter()
+            .all(|sp| sp.message() != signed_sighash)
+        {
+            eprintln!("Warning: Inconsistent sighashes in signing packages.");
+            return false;
+        }
+        match zcash_sign::confirm::confirm(signed_sighash, aux_msg.data.unwrap_or_default()) {
+            Err(_) => {
+                eprintln!("Warning: The computed sighash does not match the provided sighash.");
+                return false;
+            }
+            Ok(parsed_pczt) => {
+                parsed_pczt.print_effects(None).unwrap();
+            }
+        }
+        eprintln!("Do you want to sign the above transaction? (y/n)");
+        let mut sign_it = String::new();
+        stdin().read_line(&mut sign_it).unwrap();
+        if sign_it.trim() != "y" {
+            return false;
+        }
+        return true;
+    }
+    for signing_package in &args.signing_package {
+        eprintln!(
+            "Message to be signed (hex-encoded):\n{}\nDo you want to sign it? (y/n)",
+            hex::encode(signing_package.message())
+        );
+        let mut sign_it = String::new();
+        stdin().read_line(&mut sign_it).unwrap();
+        if sign_it.trim() != "y" {
+            return false;
+        }
+    }
+    true
+}
 
 pub async fn run(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::Participant { config, group, .. } = (*args).clone() else {
@@ -97,6 +162,7 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
                 .find(|p| p.pubkey == *coordinator_pubkey)
                 .map(|p| p.pubkey.clone())
         })),
+        confirm_message_callback: Rc::new(confirm_message::<C>),
     };
 
     let mut comms = HTTPComms::new(&args)?;

--- a/frost-client/src/coordinator/args.rs
+++ b/frost-client/src/coordinator/args.rs
@@ -49,6 +49,10 @@ pub struct Args {
     #[arg(short = 'm', long)]
     pub message: Vec<String>,
 
+    /// The content type of the messages. Defaults to "application/octet-stream".
+    #[arg(short = 't', long, default_value = "application/octet-stream")]
+    pub content_type: String,
+
     /// The randomizers to use. Each instance can be a file with the raw
     /// randomizer, "" or "-". If "" or "-" is specified, then it will be read
     /// from standard input as a hex string. If none are passed, random ones
@@ -89,6 +93,9 @@ pub struct ProcessedArgs<C: Ciphersuite> {
 
     /// An optional auxiliary message to include in the signing package.
     pub aux_msg: Option<Vec<u8>>,
+
+    /// The content type of the messages.
+    pub content_type: String,
 }
 
 impl<C: Ciphersuite + 'static> ProcessedArgs<C> {
@@ -133,6 +140,7 @@ impl<C: Ciphersuite + 'static> ProcessedArgs<C> {
             randomizers,
             // TODO: add support
             aux_msg: None,
+            content_type: args.content_type.clone(),
         })
     }
 }
@@ -222,4 +230,20 @@ pub fn read_randomizers<C: Ciphersuite + 'static>(
             .collect::<Result<_, Box<dyn Error>>>()?
     };
     Ok(randomizers)
+}
+
+pub fn write_signatures(
+    filenames: &[String],
+    signatures: &[Vec<u8>],
+) -> Result<(), Box<dyn Error>> {
+    for (signature, signature_fn) in signatures.iter().zip(filenames.iter()) {
+        if signature_fn == "-" || signature_fn.is_empty() {
+            let hex_signature = hex::encode(signature);
+            eprintln!("{hex_signature}");
+        } else {
+            fs::write(signature_fn, signature)?;
+            eprintln!("Output written to {}", signature_fn);
+        }
+    }
+    Ok(())
 }

--- a/frost-client/src/coordinator/cli.rs
+++ b/frost-client/src/coordinator/cli.rs
@@ -6,6 +6,8 @@ use frost_core::{self as frost, Ciphersuite, Signature};
 use frost_rerandomized::RandomizedCiphersuite;
 use itertools::izip;
 
+use crate::cli::coordinator::ParsedAuxMsg;
+
 use super::args::Args;
 use super::args::ProcessedArgs;
 use super::comms::cli::CLIComms;
@@ -52,11 +54,16 @@ pub async fn coordinator<C: RandomizedCiphersuite + 'static>(
             Some(pargs.randomizers)
         };
 
+        let aux_msg = postcard::to_allocvec(&ParsedAuxMsg {
+            content_type: pargs.content_type.as_str(),
+            data: pargs.aux_msg.as_deref(),
+        })?;
+
         let signature_shares = comms
             .send_signing_package_and_get_signature_shares(
                 &signing_packages,
                 randomizers.as_deref(),
-                pargs.aux_msg.clone(),
+                Some(&aux_msg),
             )
             .await?;
 

--- a/frost-client/src/coordinator/comms.rs
+++ b/frost-client/src/coordinator/comms.rs
@@ -45,7 +45,7 @@ pub trait Comms<C: Ciphersuite> {
         &mut self,
         signing_packages: &[SigningPackage<C>],
         randomizers: Option<&[frost_rerandomized::Randomizer<C>]>,
-        aux_msg: Option<Vec<u8>>,
+        aux_msg: Option<&[u8]>,
     ) -> Result<Vec<BTreeMap<Identifier<C>, SignatureShare<C>>>, Box<dyn Error>>;
 
     async fn process_signature(

--- a/frost-client/src/coordinator/comms/cli.rs
+++ b/frost-client/src/coordinator/comms/cli.rs
@@ -122,7 +122,7 @@ where
         &mut self,
         signing_packages: &[SigningPackage<C>],
         randomizers: Option<&[frost_rerandomized::Randomizer<C>]>,
-        aux_msg: Option<Vec<u8>>,
+        aux_msg: Option<&[u8]>,
     ) -> Result<Vec<BTreeMap<Identifier<C>, SignatureShare<C>>>, Box<dyn Error>> {
         // TODO: support?
         if randomizers.is_some() {

--- a/frost-client/src/coordinator/comms/http.rs
+++ b/frost-client/src/coordinator/comms/http.rs
@@ -166,7 +166,7 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
         &mut self,
         signing_packages: &[SigningPackage<C>],
         randomizers: Option<&[frost_rerandomized::Randomizer<C>]>,
-        aux_msg: Option<Vec<u8>>,
+        aux_msg: Option<&[u8]>,
     ) -> Result<Vec<BTreeMap<Identifier<C>, SignatureShare<C>>>, Box<dyn Error>> {
         eprintln!("Sending SigningPackage to participants...");
         let cipher = self
@@ -175,7 +175,7 @@ impl<C: Ciphersuite + 'static> Comms<C> for HTTPComms<C> {
             .expect("cipher must have been set before");
         let send_signing_package_args = SendSigningPackageArgs {
             signing_package: signing_packages.to_vec(),
-            aux_msg: aux_msg.unwrap_or_default(),
+            aux_msg: aux_msg.unwrap_or_default().to_vec(),
             randomizer: randomizers.map(|r| r.to_vec()).unwrap_or_default(),
         };
         // We need to send a message separately for each recipient even if the

--- a/frost-client/src/coordinator/comms/socket.rs
+++ b/frost-client/src/coordinator/comms/socket.rs
@@ -107,7 +107,7 @@ impl<C: Ciphersuite> Comms<C> for SocketComms<C> {
         &mut self,
         signing_packages: &[SigningPackage<C>],
         randomizers: Option<&[frost_rerandomized::Randomizer<C>]>,
-        aux_msg: Option<Vec<u8>>,
+        aux_msg: Option<&[u8]>,
     ) -> Result<Vec<BTreeMap<Identifier<C>, SignatureShare<C>>>, Box<dyn Error>> {
         if signing_packages.len() != 1 {
             panic!("SocketComms only supports one message at a time");

--- a/frost-client/src/coordinator/tests/steps.rs
+++ b/frost-client/src/coordinator/tests/steps.rs
@@ -107,7 +107,8 @@ async fn check_step_1() {
 
     let input = format!("{num_of_participants}\n{pub_key_package}\n");
 
-    let pargs: ProcessedArgs<frost_ed25519::Ed25519Sha512> = ProcessedArgs::new(&args, &mut input.as_bytes(), &mut buf).unwrap();
+    let pargs: ProcessedArgs<frost_ed25519::Ed25519Sha512> =
+        ProcessedArgs::new(&args, &mut input.as_bytes(), &mut buf).unwrap();
 
     let mut input = Cursor::new(format!(
         "{participant_id_1}\n{commitments_input_1}\n{participant_id_3}\n{commitments_input_3}\n"
@@ -149,7 +150,8 @@ async fn check_step_3() {
     let args = Args::default();
 
     let input = format!("2\n{pub_key_package}\n{message}\n");
-    let _pargs: ProcessedArgs<frost_ed25519::Ed25519Sha512> = ProcessedArgs::new(&args, &mut input.as_bytes(), &mut buf).unwrap();
+    let _pargs: ProcessedArgs<frost_ed25519::Ed25519Sha512> =
+        ProcessedArgs::new(&args, &mut input.as_bytes(), &mut buf).unwrap();
 
     // keygen output
 
@@ -181,12 +183,8 @@ async fn check_step_3() {
         .await
         .unwrap();
 
-    let group_signature = frost::aggregate(
-        &signing_package,
-        &signature_shares[0],
-        &pub_key_package,
-    )
-    .unwrap();
+    let group_signature =
+        frost::aggregate(&signing_package, &signature_shares[0], &pub_key_package).unwrap();
 
     comms.process_signature(&[group_signature]).await.unwrap();
 

--- a/frost-client/src/participant/comms/http.rs
+++ b/frost-client/src/participant/comms/http.rs
@@ -1,6 +1,5 @@
 //! HTTP implementation of the Comms trait.
 
-use std::io::stdin;
 use std::rc::Rc;
 use std::{error::Error, marker::PhantomData, time::Duration};
 
@@ -98,7 +97,7 @@ impl Noise {
 }
 
 #[derive(Clone)]
-pub struct Args {
+pub struct Args<C: Ciphersuite> {
     /// IP to bind to, if using socket comms.
     /// IP to connect to, if using HTTP mode.
     pub ip: String,
@@ -117,19 +116,24 @@ pub struct Args {
     pub comm_pubkey: Option<PublicKey>,
 
     /// A function that confirms that a public key from the server is trusted by
-    /// the user; returns the same public key. For HTTP mode.
+    /// the user; returns the same public key.
     // It is a `Rc<dyn Fn>` to make it easier to use;
     // using `fn()` would preclude using closures and using generics would
     // require a lot of code change for something simple.
     #[allow(clippy::type_complexity)]
     pub comm_coordinator_pubkey_getter: Option<Rc<dyn Fn(&PublicKey) -> Option<PublicKey>>>,
+
+    /// A callback to confirm the message to be signed, that must show the
+    /// message to the user and return true if they confirm signing.
+    #[allow(clippy::type_complexity)]
+    pub confirm_message_callback: Rc<dyn Fn(&SendSigningPackageArgs<C>) -> bool>,
 }
 
 pub struct HTTPComms<C: Ciphersuite> {
     client: Client,
     session_id: Option<Uuid>,
     access_token: Option<String>,
-    args: Args,
+    args: Args<C>,
     cipher: Option<Cipher>,
     _phantom: PhantomData<C>,
 }
@@ -139,7 +143,7 @@ impl<C> HTTPComms<C>
 where
     C: Ciphersuite,
 {
-    pub fn new(args: &Args) -> Result<Self, Box<dyn Error>> {
+    pub fn new(args: &Args<C>) -> Result<Self, Box<dyn Error>> {
         Ok(Self {
             client: Client::new(format!("https://{}:{}", args.ip, args.port)),
             session_id: Uuid::parse_str(&args.session_id).ok(),
@@ -305,17 +309,9 @@ where
         &mut self,
         signing_package: &SendSigningPackageArgs<C>,
     ) -> Result<(), Box<dyn Error>> {
-        // TODO: replace with callback
-        for signing_package in &signing_package.signing_package {
-            eprintln!(
-                "Message to be signed (hex-encoded):\n{}\nDo you want to sign it? (y/n)",
-                hex::encode(signing_package.message())
-            );
-            let mut sign_it = String::new();
-            stdin().read_line(&mut sign_it)?;
-            if sign_it.trim() != "y" {
-                return Err(eyre::eyre!("signing cancelled").into());
-            }
+        let confirmed = (self.args.confirm_message_callback)(signing_package);
+        if !confirmed {
+            return Err(eyre!("User did not confirm signing the message").into());
         }
         Ok(())
     }

--- a/zcash-sign/Cargo.toml
+++ b/zcash-sign/Cargo.toml
@@ -27,4 +27,5 @@ zcash_keys = { workspace = true, features = ["test-dependencies", "orchard"] }
 zcash_primitives = { workspace = true }
 zcash_proofs = { workspace = true, features = ["bundled-prover"] }
 zcash_protocol = { workspace = true }
+zcash_script = "0.4.2"
 zcash_transparent = { workspace = true, features = ["transparent-inputs"] }

--- a/zcash-sign/src/confirm.rs
+++ b/zcash-sign/src/confirm.rs
@@ -1,0 +1,424 @@
+use std::{
+    error::Error,
+    fmt::{Display, Formatter},
+};
+use zcash_primitives::transaction::TxVersion;
+
+use eyre::eyre;
+
+use pczt::Pczt;
+use zcash_primitives::transaction::{
+    sighash::SignableInput, sighash_v5::v5_signature_hash, txid::TxIdDigester,
+};
+
+pub struct ParsedPczt {
+    pub pczt: Pczt,
+}
+
+/// Confirm that the provided signed_sighash matches the computed sighash
+pub fn confirm(signed_sighash: &[u8], pczt: &[u8]) -> Result<ParsedPczt, Box<dyn Error>> {
+    let pczt = Pczt::parse(pczt).map_err(|e| eyre!("Failed to parse Pczt: {:?}", e))?;
+    let computed_sighash = match pczt.clone().into_effects() {
+        None => Err(eyre!(
+            "Not enough information to build the transaction's effects"
+        ))?,
+        Some(tx_data) => {
+            let txid_parts = tx_data.digest(TxIdDigester);
+            if matches!(tx_data.version(), TxVersion::V5)
+                && (tx_data.sapling_bundle().is_some() || tx_data.orchard_bundle().is_some())
+            {
+                v5_signature_hash(&tx_data, &SignableInput::Shielded, &txid_parts)
+            } else {
+                Err(eyre!(
+                    "Only version 5 transactions with shielded components are supported"
+                ))?
+            }
+        }
+    };
+    if signed_sighash != computed_sighash.as_bytes() {
+        Err(eyre!("sighash does not match expected value").into())
+    } else {
+        Ok(ParsedPczt { pczt })
+    }
+}
+
+impl Display for ParsedPczt {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Pczt: {:?}", self.pczt)
+    }
+}
+
+impl ParsedPczt {
+    pub fn parse(bytes: &[u8]) -> Result<Self, Box<dyn Error>> {
+        let pczt = Pczt::parse(bytes).map_err(|e| eyre!("Failed to parse Pczt: {:?}", e))?;
+        Ok(ParsedPczt::new(pczt))
+    }
+
+    pub fn new(pczt: Pczt) -> Self {
+        ParsedPczt { pczt }
+    }
+
+    pub fn print_effects(self, network: Option<Network>) -> Result<(), Box<dyn Error>> {
+        // This function was mostly copied from zcash-devtool `inspect` command
+
+        let pczt = self.pczt;
+        let seed_fp = None;
+
+        let mut transparent_inputs = vec![];
+        let mut transparent_outputs = vec![];
+        let mut sapling_spends = vec![];
+        let mut sapling_outputs = vec![];
+        let mut orchard_actions = vec![];
+
+        let pczt = Verifier::new(pczt)
+            .with_transparent(|bundle| {
+                transparent_inputs = bundle
+                    .inputs()
+                    .iter()
+                    .map(|input| {
+                        (
+                            *input.sighash_type(),
+                            input.redeem_script().clone(),
+                            input.script_pubkey().clone(),
+                            *input.value(),
+                            input
+                                .bip32_derivation()
+                                .iter()
+                                .map(|(pubkey, derivation)| {
+                                    (
+                                        *pubkey,
+                                        (
+                                            *derivation.seed_fingerprint(),
+                                            derivation.derivation_path().clone(),
+                                        ),
+                                    )
+                                })
+                                .collect::<BTreeMap<_, _>>(),
+                            input.partial_signatures().clone(),
+                        )
+                    })
+                    .collect();
+                transparent_outputs = bundle
+                    .outputs()
+                    .iter()
+                    .map(|output| (output.user_address().clone(), *output.value()))
+                    .collect();
+                Ok::<_, pczt::roles::verifier::TransparentError<()>>(())
+            })
+            .expect("no error")
+            .with_sapling(|bundle| {
+                sapling_spends = bundle.spends().iter().map(|spend| *spend.value()).collect();
+                sapling_outputs = bundle
+                    .outputs()
+                    .iter()
+                    .map(|output| {
+                        (
+                            output.user_address().clone(),
+                            *output.value(),
+                            output
+                                .zip32_derivation()
+                                .as_ref()
+                                .zip(seed_fp.as_ref())
+                                .and_then(|(derivation, (seed_fp, coin_type))| {
+                                    derivation.extract_account_index(seed_fp, *coin_type)
+                                }),
+                        )
+                    })
+                    .collect();
+                Ok::<_, pczt::roles::verifier::SaplingError<()>>(())
+            })
+            .expect("no error")
+            .with_orchard(|bundle| {
+                orchard_actions = bundle
+                    .actions()
+                    .iter()
+                    .map(|action| {
+                        (
+                            *action.spend().value(),
+                            action.output().user_address().clone(),
+                            *action.output().value(),
+                            action
+                                .output()
+                                .zip32_derivation()
+                                .as_ref()
+                                .zip(seed_fp.as_ref())
+                                .and_then(|(derivation, (seed_fp, coin_type))| {
+                                    derivation.extract_account_index(seed_fp, *coin_type)
+                                }),
+                        )
+                    })
+                    .collect();
+                Ok::<_, pczt::roles::verifier::OrchardError<()>>(())
+            })
+            .expect("no error")
+            .finish();
+
+        if !pczt.transparent().inputs().is_empty() {
+            println!("{} transparent inputs", pczt.transparent().inputs().len());
+            for (
+                index,
+                (
+                    hash_type,
+                    redeem_script,
+                    script_pubkey,
+                    value,
+                    bip32_derivation,
+                    partial_signatures,
+                ),
+            ) in transparent_inputs.iter().enumerate()
+            {
+                println!(
+                    "- {index}: {} zatoshis{}, {}",
+                    value.into_u64(),
+                    match (
+                        network,
+                        script_pubkey
+                            .refine()
+                            .ok()
+                            .as_ref()
+                            .and_then(solver::standard)
+                    ) {
+                        (Some(network), Some(solver::ScriptKind::PubKeyHash { hash })) => format!(
+                            " from {}",
+                            TransparentAddress::PublicKeyHash(hash).encode(&network)
+                        ),
+                        (Some(network), Some(solver::ScriptKind::ScriptHash { hash })) => format!(
+                            " from {}",
+                            TransparentAddress::ScriptHash(hash).encode(&network)
+                        ),
+                        _ => "".into(),
+                    },
+                    if hash_type == &SighashType::ALL {
+                        "SIGHASH_ALL"
+                    } else if hash_type == &SighashType::ALL_ANYONECANPAY {
+                        "SIGHASH_ALL_ANYONECANPAY"
+                    } else if hash_type == &SighashType::NONE {
+                        "SIGHASH_NONE"
+                    } else if hash_type == &SighashType::NONE_ANYONECANPAY {
+                        "SIGHASH_NONE_ANYONECANPAY"
+                    } else if hash_type == &SighashType::SINGLE {
+                        "SIGHASH_SINGLE"
+                    } else if hash_type == &SighashType::SINGLE_ANYONECANPAY {
+                        "SIGHASH_SINGLE_ANYONECANPAY"
+                    } else {
+                        unreachable!()
+                    },
+                );
+                println!("  Signatures present: {}", partial_signatures.len());
+                match redeem_script
+                    .as_ref()
+                    .unwrap_or(script_pubkey)
+                    .refine()
+                    .ok()
+                    .as_ref()
+                    .and_then(solver::standard)
+                {
+                    Some(script) => match script {
+                        solver::ScriptKind::PubKeyHash { .. } => {
+                            println!("  Pay-to-PubKey-Hash (P2PKH)");
+                        }
+                        solver::ScriptKind::ScriptHash { .. } => {
+                            // This case should never occur; `redeem_script` is only
+                            // omitted from P2PKH inputs of PCZTs, and P2SH-in-P2SH does
+                            // not make sense.
+                            println!("  Pay-to-Script-Hash (weird P2SH-in-P2SH)");
+                        }
+                        solver::ScriptKind::MultiSig { required, pubkeys } => {
+                            println!("  {required}-of-{} Pay-to-MultiSig (P2MS)", pubkeys.len());
+                            for pubkey in pubkeys {
+                                println!("  - {}", hex::encode(&pubkey));
+                                if let Ok(pubkey) = <[u8; 33]>::try_from(pubkey.as_slice()) {
+                                    if let Some((_, derivation_path)) =
+                                        bip32_derivation.get(&pubkey)
+                                    {
+                                        print!("    m");
+                                        for i in derivation_path {
+                                            print!(
+                                                "/{}{}",
+                                                i.index(),
+                                                if i.is_hardened() { "'" } else { "" },
+                                            );
+                                        }
+                                        println!();
+                                    }
+                                    if let Some(sig) = partial_signatures.get(&pubkey) {
+                                        println!("    Signature: {}", hex::encode(sig));
+                                    }
+                                }
+                            }
+                        }
+                        solver::ScriptKind::NullData { .. } => println!("  Null data (OP_RETURN)"),
+                        solver::ScriptKind::PubKey { .. } => println!("  Pay-to-PubKey (P2PK)"),
+                    },
+                    None => println!("  Non-standard script"),
+                }
+            }
+        }
+
+        if !pczt.transparent().outputs().is_empty() {
+            println!("{} transparent outputs", pczt.transparent().outputs().len());
+            for (index, (user_address, value)) in transparent_outputs.iter().enumerate() {
+                println!(
+                    "- {index}: {} zatoshis{}",
+                    value.into_u64(),
+                    match user_address {
+                        Some(addr) => format!(" to {addr}"),
+                        None => "".into(),
+                    }
+                );
+            }
+        }
+
+        if !pczt.sapling().spends().is_empty() {
+            println!("{} Sapling spends", pczt.sapling().spends().len());
+            for (index, value) in sapling_spends.iter().enumerate() {
+                if let Some(value) = value {
+                    if value.inner() == 0 {
+                        println!("- {index}: Zero value (likely a dummy)");
+                    } else {
+                        println!("- {index}: {} zatoshis", value.inner());
+                    }
+                }
+            }
+        }
+
+        if !pczt.sapling().outputs().is_empty() {
+            println!("{} Sapling outputs", pczt.sapling().outputs().len());
+            for (index, (user_address, value, account_index)) in sapling_outputs.iter().enumerate()
+            {
+                if let Some(value) = value {
+                    if value.inner() == 0 {
+                        println!("- {index}: Zero value (likely a dummy)");
+                    } else {
+                        println!(
+                            "- {index}: {} zatoshis{}{}",
+                            value.inner(),
+                            match user_address {
+                                Some(addr) => format!(" to {addr}"),
+                                None => "".into(),
+                            },
+                            match account_index {
+                                Some(idx) =>
+                                    format!(" (change to ZIP 32 account index {})", u32::from(*idx)),
+                                None => "".into(),
+                            }
+                        );
+                    }
+                } else if let Some(addr) = user_address {
+                    println!("- {index}: {addr}");
+                } else if let Some(idx) = account_index {
+                    println!(
+                        "- {index}: change to ZIP 32 account index {}",
+                        u32::from(*idx)
+                    );
+                }
+            }
+        }
+
+        if !pczt.orchard().actions().is_empty() {
+            println!("{} Orchard actions:", pczt.orchard().actions().len());
+            for (index, (spend_value, output_user_address, output_value, output_account_index)) in
+                orchard_actions.iter().enumerate()
+            {
+                println!("- {index}:");
+                if let Some(value) = spend_value {
+                    if value.inner() == 0 {
+                        println!("  - Spend: Zero value (likely a dummy)");
+                    } else {
+                        println!("  - Spend: {} zatoshis", value.inner());
+                    }
+                }
+                if let Some(value) = output_value {
+                    if value.inner() == 0 {
+                        println!("  - Output: Zero value (likely a dummy)");
+                    } else {
+                        println!(
+                            "  - Output: {} zatoshis{}{}",
+                            value.inner(),
+                            match output_user_address {
+                                Some(addr) => format!(" to {addr}"),
+                                None => "".into(),
+                            },
+                            match output_account_index {
+                                Some(idx) =>
+                                    format!(" (change to ZIP 32 account index {})", u32::from(*idx)),
+                                None => "".into(),
+                            }
+                        );
+                    }
+                } else if let Some(addr) = output_user_address {
+                    println!("  - Output: {addr}");
+                } else if let Some(idx) = output_account_index {
+                    println!(
+                        "- {index}: change to ZIP 32 account index {}",
+                        u32::from(*idx)
+                    );
+                }
+            }
+        }
+
+        match pczt.into_effects() {
+            None => println!("Not enough information to build the transaction's effects"),
+            Some(tx_data) => {
+                println!();
+
+                let txid_parts = tx_data.digest(TxIdDigester);
+
+                let txid = to_txid(
+                    tx_data.version(),
+                    tx_data.consensus_branch_id(),
+                    &txid_parts,
+                );
+                println!("TxID: {txid}");
+                println!("Version: {:?}", tx_data.version());
+
+                if matches!(tx_data.version(), TxVersion::V5) {
+                    if tx_data.sapling_bundle().is_some() || tx_data.orchard_bundle().is_some() {
+                        let shielded_sighash =
+                            v5_signature_hash(&tx_data, &SignableInput::Shielded, &txid_parts);
+                        println!(
+                            "Sighash for shielded components: {}",
+                            hex::encode(shielded_sighash)
+                        );
+                    }
+
+                    if tx_data.transparent_bundle().is_some() {
+                        println!("Sighashes for each transparent input:");
+                        for (index, (hash_type, redeem_script, script_pubkey, value, _, _)) in
+                            transparent_inputs.into_iter().enumerate()
+                        {
+                            let sighash = v5_signature_hash(
+                                &tx_data,
+                                &SignableInput::Transparent(
+                                    zcash_transparent::sighash::SignableInput::from_parts(
+                                        hash_type,
+                                        index,
+                                        &redeem_script.as_ref().unwrap_or(&script_pubkey).into(), // for p2pkh, always the same as script_pubkey
+                                        &script_pubkey.into(),
+                                        value,
+                                    ),
+                                ),
+                                &txid_parts,
+                            );
+
+                            println!("- {index}: {}", hex::encode(sighash));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+use std::collections::BTreeMap;
+
+use pczt::roles::verifier::Verifier;
+
+use zcash_keys::encoding::AddressCodec;
+use zcash_primitives::transaction::txid::to_txid;
+use zcash_protocol::consensus::Network;
+use zcash_script::solver;
+use zcash_transparent::address::TransparentAddress;
+use zcash_transparent::sighash::SighashType;

--- a/zcash-sign/src/lib.rs
+++ b/zcash-sign/src/lib.rs
@@ -1,7 +1,12 @@
+pub mod confirm;
 mod generate;
 mod sign;
 pub(crate) mod sign_ywallet;
 pub mod transaction_plan;
 
 pub use generate::generate;
-pub use sign::{sign, Input};
+pub use sign::{
+    read_pczt_signining_inputs, sign, write_pczt_signing_outputs, Input, SigningInputs,
+};
+
+pub const PCZT_CONTENT_TYPE: &str = "application/vnd.zcash.pczt";

--- a/zcash-sign/src/main.rs
+++ b/zcash-sign/src/main.rs
@@ -4,7 +4,6 @@ use std::{error::Error, fs};
 
 use clap::Parser as _;
 use eyre::eyre;
-use pczt::Pczt;
 use rand::{thread_rng, RngCore};
 
 use orchard::keys::{Scope, SpendValidatingKey};
@@ -14,6 +13,7 @@ use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_protocol::consensus::{self};
 
 use args::{Args, Command};
+use zcash_sign::confirm::ParsedPczt;
 
 fn generate(args: &Command) -> Result<(), Box<dyn Error>> {
     let Command::Generate {
@@ -79,7 +79,7 @@ fn sign(args: &Command) -> Result<(), Box<dyn Error>> {
     };
 
     let tx_plan = fs::read(tx_plan)?;
-    let input = match Pczt::parse(&tx_plan) {
+    let input = match ParsedPczt::parse(&tx_plan) {
         Ok(pczt) => zcash_sign::Input::Pczt(pczt),
         Err(_) => zcash_sign::Input::YwalletTxPlan(serde_json::from_slice(&tx_plan)?),
     };

--- a/zcash-sign/src/sign.rs
+++ b/zcash-sign/src/sign.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use eyre::eyre;
-use pczt::{roles::low_level_signer::Signer, Pczt};
+use pczt::roles::low_level_signer::Signer;
 use rand_core::{CryptoRng, RngCore};
 
 use halo2_proofs::pasta::group::ff::PrimeField;
@@ -13,11 +13,11 @@ use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::transaction::{sighash::SignableInput, txid::TxIdDigester};
 use zcash_primitives::transaction::{sighash_v5::v5_signature_hash, TxVersion};
 
-use crate::transaction_plan::TransactionPlan;
+use crate::{confirm::ParsedPczt, transaction_plan::TransactionPlan};
 
 pub enum Input {
     YwalletTxPlan(TransactionPlan),
-    Pczt(Pczt),
+    Pczt(ParsedPczt),
 }
 
 /// Sign a transaction plan with externally-generated signatures.
@@ -38,11 +38,14 @@ pub fn sign(
     }
 }
 
-fn sign_pczt(
-    _rng: impl RngCore + CryptoRng,
-    _network: zcash_protocol::consensus::Network,
-    pczt: &Pczt,
-) -> Result<Vec<u8>, Box<dyn Error>> {
+pub struct SigningInputs {
+    pub sighash: Vec<u8>,
+    pub alphas: Vec<(usize, Vec<u8>)>,
+}
+
+/// Return the sighash and alphas (randomizers) from the PCZT.
+pub fn read_pczt_signining_inputs(pczt: &ParsedPczt) -> Result<SigningInputs, Box<dyn Error>> {
+    let pczt = &pczt.pczt;
     let sighash = match pczt.clone().into_effects() {
         None => Err(eyre!(
             "Not enough information to build the transaction's effects"
@@ -59,12 +62,11 @@ fn sign_pczt(
                 ))?
             }
         }
-    };
-
-    println!("SIGHASH: {}", hex::encode(sighash));
+    }
+    .as_bytes()
+    .to_vec();
 
     let signer = Signer::new(pczt.clone());
-
     let mut alphas = vec![];
     signer
         .sign_orchard_with(|_pczt, bundle, _| {
@@ -76,7 +78,7 @@ fn sign_pczt(
                 .filter_map(|(idx, a)| {
                     // TODO: improve dummy detection (check rk instead)
                     if a.spend().value().unwrap() != NoteValue::default() {
-                        Some((idx, a.spend().alpha().unwrap()))
+                        Some((idx, a.spend().alpha().unwrap().to_repr().to_vec()))
                     } else {
                         None
                     }
@@ -86,13 +88,62 @@ fn sign_pczt(
         })
         .unwrap();
 
+    Ok(SigningInputs { sighash, alphas })
+}
+
+pub fn write_pczt_signing_outputs(
+    pczt: &ParsedPczt,
+    sighash: &[u8],
+    signatures: &[Vec<u8>],
+) -> Result<Vec<u8>, Box<dyn Error>> {
+    let signatures = signatures
+        .iter()
+        .map(|sig_bytes| {
+            let sig_array: [u8; 64] = sig_bytes
+                .clone()
+                .try_into()
+                .map_err(|_| eyre!("Signature must be exactly 64 bytes long"))?;
+            Ok(redpallas::Signature::<SpendAuth>::from(sig_array))
+        })
+        .collect::<Result<Vec<_>, Box<dyn Error>>>()?;
+
+    let signer = Signer::new(pczt.pczt.clone());
+    let signer = signer
+        .sign_orchard_with(|_pczt, bundle, _| {
+            bundle
+                .actions_mut()
+                .iter_mut()
+                // TODO: remove unwrap
+                .filter(|a| {
+                    // TODO: improve dummy detection (check rk instead)
+                    a.spend().value().unwrap() != NoteValue::default()
+                })
+                .zip(signatures.iter())
+                .for_each(|(action, signature)| {
+                    action
+                        .apply_signature(sighash.try_into().unwrap(), signature.clone())
+                        .unwrap();
+                });
+            Ok::<_, orchard::pczt::ParseError>(())
+        })
+        .map_err(|e| eyre!("Error signing: {:?}", e))?;
+    let pczt = signer.finish();
+
+    Ok(pczt.serialize())
+}
+
+fn sign_pczt(
+    _rng: impl RngCore + CryptoRng,
+    _network: zcash_protocol::consensus::Network,
+    pczt: &ParsedPczt,
+) -> Result<Vec<u8>, Box<dyn Error>> {
+    let SigningInputs { sighash, alphas } = read_pczt_signining_inputs(pczt)?;
+
+    println!("SIGHASH: {}", hex::encode(&sighash));
+
     let mut signatures = vec![];
     for (idx, alpha) in alphas.iter() {
-        println!(
-            "Randomizer #{}: {}",
-            idx,
-            hex::encode::<&[u8]>(alpha.to_repr().as_ref())
-        );
+        println!("Randomizer #{}: {}", idx, hex::encode(alpha));
     }
     for (idx, _alpha) in alphas.iter() {
         let mut buffer = String::new();
@@ -100,24 +151,8 @@ fn sign_pczt(
         println!("Input hex-encoded signature #{idx}: ");
         stdin.read_line(&mut buffer).unwrap();
         let signature = hex::decode(buffer.trim()).unwrap();
-        let signature: [u8; 64] = signature.try_into().unwrap();
-        let signature = redpallas::Signature::<SpendAuth>::from(signature);
-        signatures.push((*idx, signature));
+        signatures.push(signature);
     }
 
-    let signer = Signer::new(pczt.clone());
-    let signer = signer
-        .sign_orchard_with(|_pczt, bundle, _| {
-            for (idx, signature) in signatures.into_iter() {
-                let action = &mut bundle.actions_mut()[idx];
-                action
-                    .apply_signature(sighash.as_bytes().try_into().unwrap(), signature)
-                    .unwrap();
-            }
-            Ok::<_, orchard::pczt::ParseError>(())
-        })
-        .map_err(|e| eyre!("Error signing: {:?}", e))?;
-    let pczt = signer.finish();
-
-    Ok(pczt.serialize())
+    write_pczt_signing_outputs(pczt, &sighash, &signatures)
 }


### PR DESCRIPTION
Based on top of #579, which must be merged first.

Allow specifying the content-type of the message in the frost-client CLI; and if it is a PCZT, confirm if the sighash matches and print the PCZT contents for confirmation, and also write the signed PCZT instead of the raw signature.